### PR TITLE
cmake/GetArch: Use x86_64 for windows plugins (#2027)

### DIFF
--- a/cmake/GetArch.cmake
+++ b/cmake/GetArch.cmake
@@ -28,7 +28,8 @@ function(GetArch)
       endif()
     endif ()
   else (NOT WIN32)
-    # On WIN32 probably CMAKE_SIZEOF_VOID_P EQUAL 8, but we don't use it at all now...
+    # Should really be i386 since we are on win32. However, it's
+    # x86_64 for now, see #2027
     set (ARCH "i386")
   endif (NOT WIN32)
   set (ARCH ${ARCH} PARENT_SCOPE)


### PR DESCRIPTION
Upstream bug: https://github.com/OpenCPN/OpenCPN/issues/2027

as discussed in #13