### PR TITLE
Fix arch, clean up tarball garbage.

### DIFF
--- a/cmake/GetArch.cmake
+++ b/cmake/GetArch.cmake
@@ -30,7 +30,7 @@ function(GetArch)
   else (NOT WIN32)
     # Should really be i386 since we are on win32. However, it's
     # x86_64 for now, see #2027
-    set (ARCH "i386")
+    set (ARCH "x86_64")
   endif (NOT WIN32)
   set (ARCH ${ARCH} PARENT_SCOPE)
 endfunction(GetArch)

--- a/cmake/metadata.cmake
+++ b/cmake/metadata.cmake
@@ -90,6 +90,7 @@ set(repack_tarball_script
 tmpdir=repack.$$
 rm -rf $tmpdir && mkdir $tmpdir
 tar -C $tmpdir -xf $1
+rm -rf $tmpdir/root
 cp $2 $tmpdir/*/
 tar -C $tmpdir -czf $1 .
 rm -rf $tmpdir


### PR DESCRIPTION
So, I produced some interesting comments about the i386 -> x86_64 issue. But, I didn't actually fix the code. 

Sigh. While on it, remove some garbage in the tarball generated by CPack (why?)