### PR TITLE
Cleanup: drop redundant code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,6 @@ jobs:
       - OCPN_TARGET:  bionic
     steps:
       - checkout
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic main"
-          | sudo tee -a /etc/apt/sources.list
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates main"
-          | sudo tee -a /etc/apt/sources.list
       - run: cat /etc/apt/sources.list
       - run: ci/circleci-build-debian.sh
       - run: cd build; /bin/bash < upload.sh
@@ -69,13 +63,6 @@ jobs:
         - OCPN_TARGET:  bionic-gtk3
         steps:
         - checkout
-        - run: >
-            echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic main"
-            | sudo tee -a /etc/apt/sources.list
-        - run: >
-            echo
-            "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates main"
-            | sudo tee -a /etc/apt/sources.list
         - run: ci/circleci-build-debian.sh
         - run: cd build; /bin/bash < upload.sh
 
@@ -87,12 +74,6 @@ jobs:
       - BUILD_GTK3: true
     steps:
       - checkout
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ focal main"
-          | sudo tee -a /etc/apt/sources.list
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ focal-updates main"
-          | sudo tee -a /etc/apt/sources.list
       - run: cat /etc/apt/sources.list
       - run: ci/circleci-build-debian.sh
       - run: cd build; /bin/bash < upload.sh
@@ -104,12 +85,6 @@ jobs:
       - OCPN_TARGET: buster
     steps:
       - checkout
-      - run: >
-          echo "deb-src http://ftp.us.debian.org/debian buster main"
-          | sudo tee -a /etc/apt/sources.list
-      - run: >
-          echo "deb-src http://ftp.us.debian.org/debian buster-updates main"
-          | sudo tee -a /etc/apt/sources.list
       - run: ci/circleci-build-debian.sh
       - run: cd build; /bin/bash < upload.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,6 @@ jobs:
       - OCPN_TARGET:  xenial
     steps:
       - checkout
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main"
-          | sudo tee -a /etc/apt/sources.list
-      - run: >
-          echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-updates main"
-          | sudo tee -a /etc/apt/sources.list
       - run: cat /etc/apt/sources.list
       - run: ci/circleci-build-debian.sh
       - run: cd build; /bin/bash < upload.sh

--- a/ci/circleci-build-raspbian-armhf.sh
+++ b/ci/circleci-build-raspbian-armhf.sh
@@ -55,6 +55,4 @@ rm -f build.sh
 
 
 # Install cloudsmith-cli,  required by upload.sh.
-sudo apt-get -q update
-sudo apt-get install python3-pip python3-setuptools
 pip3 install cloudsmith-cli

--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -3,10 +3,6 @@
 #
 # Upload the .tar.gz and .xml artifacts to cloudsmith
 #
-# Uploading requires that the environment variable CLOUDSMITH_API_KEY is
-# set to value available in the Cloudsmith GUI. Usually, also the repos
-# used for tagged and untagged builds  needs to be set using the
-# environment variables CLOUDSMITH_STABLE_REPO and CLOUDSMITH_UNSTABLE_REPO
 
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Warning: $CLOUDSMITH_API_KEY is not available, upload will fail.'
@@ -27,5 +23,3 @@ set -xe
     --version @pkg_semver@ \
     --summary "Plugin tarball for automatic installation" \
     @pkg_repo@ @pkg_tarname@.tar.gz
-
-set +x


### PR DESCRIPTION
Also cuts some time from the slow raspbian-armhf builders.