### PR TITLE
Finalizing:  minor bugs and tweaks.

### DIFF
--- a/cmake/PluginCompiler.cmake
+++ b/cmake/PluginCompiler.cmake
@@ -21,7 +21,10 @@ elseif (COMPILER STREQUAL "MSVC")
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE)
 endif ()
 
-if (UNIX AND NOT APPLE)   # linux.
+if (UNIX AND NOT APPLE)   # linux, see OpenCPN/OpenCPN#1977
   set_target_properties(${PACKAGE_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN:$ORIGIN/..")
 endif ()
 
+if (NOT COMPILER STREQUAL "MSVC")
+  set(OBJ_VISIBILITY "-fvisibility=hidden")
+endif ()

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -32,7 +32,7 @@ endif ()
 
 if (MINGW)
   target_link_libraries(${PACKAGE_NAME} ${OPENGL_LIBRARIES})
-  set(CMAKE_SHARED_LINKER_FLAGS "-L../buildwin")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L../buildwin")
 endif ()
 
 

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -50,10 +50,10 @@ set (tar_script
 set -x
 TAR=$(echo ${TAR} | tr ' ' '*')
 
-$TAR -C ${CMAKE_BINARY_DIR} \
+$TAR -C ${CMAKE_BINARY_DIR}/app \
      -czf ${pkg_tarname}.tar.gz \
-     --transform 's|.*/files|${pkg_displayname}|' \
-     app"
+     --transform 's|files|${pkg_displayname}|' \
+     files"
 )
 file(WRITE ${CMAKE_BINARY_DIR}/tarball.sh ${tar_script})
 
@@ -100,13 +100,6 @@ function (flatpak_target manifest)
     TARGET flatpak-conf
     COMMAND cmake -DBUILD_TYPE:STRING=flatpak -UPKG_TARGET ${CMAKE_BINARY_DIR}
   )
-  add_custom_target(flatpak-tar)
-  add_custom_command(
-    TARGET flatpak-tar
-    COMMAND bash < ${CMAKE_BINARY_DIR}/tarball.sh
-    VERBATIM
-    COMMENT "building ${pkg_tarname}.tar.gz"
-  )
   add_custom_target(
     flatpak-build          # Build the package using flatpak-builder
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -117,6 +110,13 @@ function (flatpak_target manifest)
     flatpak-pkg            # Move metadata in place.
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMAND bash -c \"cp ${pkg_displayname}.xml app/files/metadata.xml\"
+  )
+  add_custom_target(flatpak-tar)
+  add_custom_command(
+    TARGET flatpak-tar
+    COMMAND bash < ${CMAKE_BINARY_DIR}/tarball.sh
+    VERBATIM
+    COMMENT "building ${pkg_tarname}.tar.gz"
   )
   add_dependencies(flatpak-build flatpak-conf)
   add_dependencies(flatpak-pkg flatpak-build)

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -48,7 +48,6 @@ find_program(TAR NAMES gtar tar REQUIRED)
 #   Handle paths containing slashes, using / also on Windows
 string(REPLACE "\\" "/" TAR ${TAR})
 string(REPLACE " " "\\ " TAR ${TAR})
-message(STATUS "TAR: ${TAR}")
 set (tar_script
 "#!/bin/bash
 set -x
@@ -173,18 +172,18 @@ function (help_target)
   )
 
   if ("${BUILD_TYPE}" STREQUAL "" )
-  add_dependencies(${PACKAGE_NAME} make-warning)
+    add_dependencies(${PACKAGE_NAME} make-warning)
   endif ()
 endfunction ()
 
 function (create_targets manifest)
- # Add the primary build targets pkg, flatpak and tarball together
- # with helper targets. Parameters:
- # - manifest: Flatpak build manifest
+  # Add the primary build targets pkg, flatpak and tarball together
+  # with helper targets. Parameters:
+  # - manifest: Flatpak build manifest
 
- tarball_target()
- flatpak_target(${manifest})
- pkg_target()
- help_target()
+  tarball_target()
+  flatpak_target(${manifest})
+  pkg_target()
+  help_target()
 endfunction ()
 

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -45,15 +45,17 @@ endif ()
 
 # Create the tarball.sh script which generates the tarball
 find_program(TAR NAMES gtar tar REQUIRED)
+#   Handle paths containing slashes, using / also on Windows
+string(REPLACE "\\" "/" TAR ${TAR})
+string(REPLACE " " "\\ " TAR ${TAR})
+message(STATUS "TAR: ${TAR}")
 set (tar_script
 "#!/bin/bash
 set -x
-TAR=$(echo ${TAR} | tr ' ' '*')
-
-$TAR -C ${CMAKE_BINARY_DIR}/app \
-     -czf ${pkg_tarname}.tar.gz \
-     --transform 's|files|${pkg_displayname}|' \
-     files"
+${TAR} -C ${CMAKE_BINARY_DIR}/app \
+    -czf ${pkg_tarname}.tar.gz \
+    --transform 's|files|${pkg_displayname}|' \
+    files"
 )
 file(WRITE ${CMAKE_BINARY_DIR}/tarball.sh ${tar_script})
 


### PR DESCRIPTION
As discussed:

  - Drop bugus /app from tarball
  - Don't drop user's CMAKE_SHARED_LINKER_FLAGS
  - Set up -fvisibility as applicable.
  - A little more careful with windows paths with spaces (and mac, for sure)
  - Drop debugging, clean up.

Feels reasonable safe, this one. New try: this should be the end of it, besides bugfixes. Unless you  have remarks or ideas.

I have been contemplating the idea to name the upload something like ShipDriver-5.2_ubuntu-18.04 instead of current ShipDriver_ubuntu-18.04. It would be a simple fix, basically a oneliner. Thoughts?

--a