### PR TITLE
win32: Sanitize install paths.

### DIFF
--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -29,7 +29,6 @@ if (APPLE)
 
 elseif (WIN32)
   message(STATUS "Install Prefix: ${CMAKE_INSTALL_PREFIX}")
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/../OpenCPN)
   if (CMAKE_CROSSCOMPILING)
     install(TARGETS ${PACKAGE_NAME} RUNTIME DESTINATION "plugins")
     set(INSTALL_DIRECTORY "plugins/${PACKAGE_NAME}")
@@ -52,8 +51,10 @@ elseif (UNIX AND NOT APPLE)
   endif ()
 endif ()
 
-# Hardcoded destination for tarball generation
-install(FILES ${CMAKE_BINARY_DIR}/${pkg_displayname}.xml
-        DESTINATION "${CMAKE_BINARY_DIR}/app/files"
-        RENAME metadata.xml
-)
+# Hardcoded, absolute destination for tarball generation
+if (${BUILD_TYPE} STREQUAL "tarball" OR ${BUILD_TYPE} STREQUAL "flatpak")
+  install(FILES ${CMAKE_BINARY_DIR}/${pkg_displayname}.xml
+          DESTINATION "${CMAKE_BINARY_DIR}/app/files"
+          RENAME metadata.xml
+  )
+endif()


### PR DESCRIPTION
I had a commit on my side which I didn't push in the PR. This was the reason this time. This commit should be the last one w r t make tarball.

Builds fine by me using this batch file:
```
call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
set WXWIN=C:\wxWidgets-3.1.2
set wxWidgets_ROOT_DIR=%WXWIN%
set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
set PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
set PATH=C:\Program Files\Cmake\bin;%PATH%

rem choco install poedit
rem download, unpack and install
rem http://opencpn.navnux.org/build_deps/OpenCPN_buildwin-4.99a.7z
rem into C:\wxWidgets-3.2.1


git clone  https://github.com/leamas/shipdriver_pi.git
cd shipdriver_pi
git fetch origin ms-install:ms-install
git checkout ms-install
mkdir  build
cd build
cmake -T v141_xp ..
cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
cmake --build . --target tarball --config RelWithDebInfo
```


Note that it clones the PR branch on my side, you want to change that...
