### PR TITLE
Ci update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,18 @@
 ---
-version: 2
+version: 2.1
+
+debian-steps: &debian-steps
+  steps:
+    - checkout
+    - run: ci/circleci-build-debian.sh
+    - run: cd build; /bin/bash < upload.sh
+
 jobs:
   build-mingw:
     machine:
       image: circleci/classic:201808-01
     environment:
-      - OCPN_TARGET:  mingw
+      - OCPN_TARGET: mingw
     steps:
       - checkout
       - run: ci/circleci-build-mingw.sh
@@ -15,99 +22,81 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     environment:
-      - OCPN_TARGET:  flatpak
+      - OCPN_TARGET: flatpak
     steps:
       - checkout
       - restore_cache:
-           keys:
-              - fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
+          keys:
+            - fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
       - run: ci/circleci-build-flatpak.sh
       - save_cache:
-           key: fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
-           paths:
-             - /home/circleci/.local/share/flatpak/repo
+          key: fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
+          paths:
+            - /home/circleci/.local/share/flatpak/repo
       - run: cd build; /bin/bash < upload.sh
 
   build-macos:
     macos:
       xcode: "11.0.0"
     environment:
-      - OCPN_TARGET:  macos
+      - OCPN_TARGET: macos
     steps:
       - checkout
       - restore_cache:
-           keys:
-              - macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
+          keys:
+            - macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
       - run: ci/circleci-build-macos.sh
       - save_cache:
-           key: macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
-           paths:
-             - /usr/local/Homebrew
-             - /usr/local/Cellar
-             - /usr/local/lib
-             - /usr/local/include
+          key: macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
+          paths:
+            - /usr/local/Homebrew
+            - /usr/local/Cellar
+            - /usr/local/lib
+            - /usr/local/include
       - run: cd build; /bin/bash < upload.sh
 
   build-trusty:
     docker:
       - image: circleci/buildpack-deps:trusty-scm
     environment:
-      - OCPN_TARGET:  trusty
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+      - OCPN_TARGET: trusty
+    <<: *debian-steps
 
   build-xenial:
     docker:
       - image: circleci/buildpack-deps:xenial-scm
     environment:
-      - OCPN_TARGET:  xenial
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+      - OCPN_TARGET: xenial
+    <<: *debian-steps
 
   build-bionic:
     docker:
       - image: circleci/buildpack-deps:bionic-scm
     environment:
-      - OCPN_TARGET:  bionic
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+      - OCPN_TARGET: bionic
+    <<: *debian-steps
 
   build-bionic-gtk3:
     docker:
       - image: circleci/buildpack-deps:bionic-scm
     environment:
       - BUILD_GTK3: true
-      - OCPN_TARGET:  bionic-gtk3
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+      - OCPN_TARGET: bionic-gtk3
+    <<: *debian-steps
 
   build-focal:
     docker:
       - image: circleci/buildpack-deps:focal-scm
     environment:
-      - OCPN_TARGET:  focal
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+      - OCPN_TARGET: focal
+    <<: *debian-steps
 
   build-buster:
     docker:
       - image: circleci/buildpack-deps:buster-scm
     environment:
       - OCPN_TARGET: buster
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian.sh
-      - run: cd build; /bin/bash < upload.sh
+    <<: *debian-steps
 
   build-armhf-stretch:
     machine: true
@@ -131,84 +120,46 @@ jobs:
       - run: ci/circleci-build-raspbian-armhf.sh
       - run: cd build; /bin/bash < upload.sh
 
+std-filters: &std-filters
+  filters:
+    branches:
+      only:
+        - master
+        - build
 
 workflows:
   version: 2
   build_all:
     jobs:
       - build-mingw:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
+
       - build-flatpak:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
+
       - build-macos:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-trusty:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-xenial:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
-
+          <<: *std-filters
 
       - build-bionic-gtk3:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-bionic:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-focal:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-buster:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters
 
       - build-armhf-stretch:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
-
+          <<: *std-filters
 
       - build-armhf-buster:
-          filters:
-            branches:
-              only:
-                  - master
-                  - build
+          <<: *std-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,19 @@ jobs:
 
   build-flatpak:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:201903-01
     environment:
       - OCPN_TARGET:  flatpak
     steps:
       - checkout
+      - restore_cache:
+           keys:
+              - fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
       - run: ci/circleci-build-flatpak.sh
+      - save_cache:
+           key: fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
+           paths:
+             - /home/circleci/.local/share/flatpak/repo
       - run: cd build; /bin/bash < upload.sh
 
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,22 @@ jobs:
 
   build-macos:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.0.0"
     environment:
       - OCPN_TARGET:  macos
     steps:
       - checkout
+      - restore_cache:
+           keys:
+              - macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
       - run: ci/circleci-build-macos.sh
+      - save_cache:
+           key: macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
+           paths:
+             - /usr/local/Homebrew
+             - /usr/local/Cellar
+             - /usr/local/lib
+             - /usr/local/include
       - run: cd build; /bin/bash < upload.sh
 
   build-trusty:

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ and a .dmg image for MacOS:
 
     $ cmake ..
     $ make pkg
+
+#### Building on windows (MSVC)
+On windows, a somewhat different workflow is used:
+
+    > cmake -T v141\_xp ..
+    > cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+    > cmake --build . --target tarball --config RelWithDebInfo
+
+This is to build the installer tarball. Use _--target pkg_ to build the
+legacy NSIS installer. The build requires access to a specific wxWidgets
+3.1.2 build, see the appveyour.yml file for details.
+

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -1,6 +1,6 @@
 #
 # Set up variables for configuration of xml metadata and upload scripts, all of
-# which with a pkg_ prefix. Also add the repack-tarball target
+# which with a pkg_ prefix.
 #
 
 #cmake-format: off

--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -19,7 +19,6 @@ if (APPLE)
     RUNTIME
     LIBRARY DESTINATION OpenCPN.app/Contents/PlugIns
   )
-
   if (EXISTS ${PROJECT_SOURCE_DIR}/data)
     install(
       DIRECTORY data

--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -177,7 +177,6 @@ endif (TWIN32 AND NOT UNIX)
 include(CPack)
 
 if (APPLE)
-
   # Copy a bunch of files so the Packages installer builder can find them
   # relative to ${CMAKE_CURRENT_BINARY_DIR} This avoids absolute paths in the
   # chartdldr_pi.pkgproj file
@@ -186,7 +185,6 @@ if (APPLE)
     ${PROJECT_SOURCE_DIR}/COPYING ${CMAKE_CURRENT_BINARY_DIR}/license.txt
     COPYONLY
   )
-
   configure_file(
     ${PROJECT_SOURCE_DIR}/buildosx/InstallOSX/pkg_background.jpg
     ${CMAKE_CURRENT_BINARY_DIR}/pkg_background.jpg COPYONLY
@@ -200,7 +198,6 @@ if (APPLE)
     ${PROJECT_SOURCE_DIR}/buildosx/InstallOSX/${PACKAGE_NAME}.pkgproj.in
     ${CMAKE_CURRENT_BINARY_DIR}/${VERBOSE_NAME}.pkgproj
   )
-
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${VERBOSE_NAME}-Plugin.pkg
     COMMAND /usr/local/bin/packagesbuild -F ${CMAKE_CURRENT_BINARY_DIR}
@@ -209,13 +206,11 @@ if (APPLE)
     DEPENDS ${PACKAGE_NAME}
     COMMENT "create-pkg [${PACKAGE_NAME}]: Generating pkg file."
   )
-
   add_custom_target(
     create-pkg
     COMMENT "create-pkg: Done."
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${VERBOSE_NAME}-Plugin.pkg
   )
-
 endif (APPLE)
 
 if (WIN32)
@@ -235,5 +230,4 @@ if (WIN32)
     COMMENT "code signing: Done."
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${CPACK_PACKAGE_FILE_NAME}
   )
-
-endif (WIN32)
+endif ()

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -37,8 +37,8 @@ if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 16)
   set(_build_target_cmd make)
   set(_install_cmd make install)
 else ()
-  set(_build_target_cmd cmake
-    --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target
+  set(_build_target_cmd
+      cmake --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target
   )
   set(_install_cmd cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
 endif ()

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -43,7 +43,7 @@ else ()
   set(_install_cmd cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
 endif ()
 
-if (WIN32)
+if (WIN32 AND NOT MINGW)
   set(MVDIR rename)
 else ()
   set(MVDIR mv)

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -18,9 +18,8 @@ To build and install:
   - The shipdriver flatpak plugin can now be built and installed using
 
         $ cd build
-        $ cmake .. -DOCPN_FLATPAK:BOOL=ON
-        $ make flatpak-build
-        $ make flatpak-pkg
+        $ cmake ..
+        $ make flatpak
 
 Build produces a plugin tarball and metadata file, to be used with the new
 plugin installer available from 5.2.0. See the README.md in top directory.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,8 +1,8 @@
 Shipdriver flatpak README
 -------------------------
 
-This is a simple packaging to be used together with  opencpn's flatpak
-package. To build and install:
+A simple packaging to be used together with  opencpn's flatpak package.
+To build and install:
 
   - Install flatpak and flatpak-builder as described in https://flatpak.org/
   - Install the opencpn  flatpak package using latest official version on


### PR DESCRIPTION
Overhaul of the ci setup:

  - Mingw buildfix
  - Rewrite macos script, clean up homebrew handling, add caching. Build times down from around 6  to two minutes.
  - Rewrite flatpak script, drop the nested Fedora docker builder, add caching. Build times down from around 5 to 2.5 minutes
  - Rewrite the .circleci/config file using anchors, makes the file shorter and easier to maintain 

circleci logs: https://app.circleci.com/pipelines/github/leamas/shipdriver_pi/350/workflows/7075defb-008b-482b-8f0d-d8ab43ed79aa
travis logs: https://travis-ci.com/github/leamas/shipdriver_pi
appveyor logs: https://ci.appveyor.com/project/leamas/shipdriver-pi