### PR TITLE
Json: temporary fix for dysfunctional dynamic linkage to jsoncpp library 

### DIFF
--- a/libs/jsoncpp/CMakeLists.txt
+++ b/libs/jsoncpp/CMakeLists.txt
@@ -20,7 +20,11 @@ if (JSONCPP_LIBRARY AND JSONCPP_INCLUDE_DIR AND USE_SYSTEM_JSONCPP)
   return ()
 endif ()
 
-if (${CMAKE_VERSION} VERSION_GREATER "3.8.0" AND NOT WIN32)
+if ((${CMAKE_VERSION} VERSION_GREATER "3.8.0" AND NOT WIN32)
+  # FIXME: Always bundles large jsoncpp library, should use system when
+  # available.
+  AND NOT ${BUILD_TYPE} STREQUAL "tarball"
+)
   include("CMakeLists-org.txt")
 else ()
   set(SRC src/lib_json/json_reader.cpp


### PR DESCRIPTION
As heading says: Ensure that jsoncpp is statically linked on all tarballs. Unfortunately increases the  plugin library file size with about 250K.