### PR TITLE
ci: macos: Cleanup.

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -9,7 +9,7 @@ set -xe
 # Check if the cache is with us. If not, re-install brew.
 brew list --versions libexif || brew update-reset
 
-for pkg in cairo cmake libarchive libexif python wget; do
+for pkg in cairo cmake gettext libarchive libexif python wget; do
     brew list --versions $pkg || brew install $pkg || brew install $pkg || :
     brew link --overwrite $pkg || brew install $pkg
 done

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -7,7 +7,7 @@ set -xe
 
 #
 # Check if the cache is with us. If not, re-install brew.
-brew list --versions cmake || brew update-reset
+brew list --versions libexif || brew update-reset
 
 for pkg in cairo cmake libarchive libexif python wget; do
     brew list --versions $pkg || brew install $pkg || brew install $pkg || :
@@ -16,20 +16,16 @@ done
 
 wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
 tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
-export PATH="/usr/local/opt/gettext/bin:$PATH"
-echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile
 
 export MACOSX_DEPLOYMENT_TARGET=10.9
 
 rm -rf build && mkdir build && cd build
 cmake \
   -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config \
-  -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312_opencpn50_macos109" \
-  -DCMAKE_INSTALL_PREFIX= \
+  -DCMAKE_INSTALL_PREFIX="/" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
-  "/" \
   ..
-make -sj2 tarball
+make tarball
 make pkg
 
 wget -q http://opencpn.navnux.org/build_deps/Packages.dmg
@@ -37,5 +33,5 @@ hdiutil attach Packages.dmg
 sudo installer -pkg "/Volumes/Packages 1.2.5/Install Packages.pkg" -target "/"
 make create-pkg
 
-
+# Install cloudsmith needed by upload script
 pip3 install cloudsmith-cli


### PR DESCRIPTION
Still more more cruft to remove, and what's probably a rebasing error; the latter was such that it was really strange that cmake accepted it.

Anyway cleanup of circleci-build-macos. I have loaded the tarball into my MacOS VM, no crashes from start.