### PR TITLE
cmake: Targets: Don't use -C flag if no <CONFIG> exists.

### DIFF
--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -152,7 +152,7 @@ function (pkg_target)
   add_custom_command(
     TARGET pkg-package
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND cpack -C $<CONFIG>
+    COMMAND cpack $<$<BOOL:$<CONFIG>>:"-C $<CONFIG>">
   )
   add_dependencies(pkg-build pkg-conf)
   add_dependencies(pkg-package pkg-build)


### PR DESCRIPTION
As heading says: Either use just _cpack_ or _cpack -C config_. Current code basically collapses to  _cpack -C_ if config isn't defined. The horrifying fact is that cpack in this case silently fails without doing anything at all, at least on Linux.

Sigh.

Also: the generator expressions syntax is indeed awkward. Cannot to much about it...