### PR TITLE
cmake: target: Fix missing metadata in 'make tarball'.

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -26,7 +26,6 @@ cmake \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 make tarball
-make pkg
 
 wget -q http://opencpn.navnux.org/build_deps/Packages.dmg
 hdiutil attach Packages.dmg

--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -65,7 +65,10 @@ set(CPACK_SOURCE_IGNORE_FILES
     "^${CPACK_PACKAGE_INSTALL_DIRECTORY}/*"
 )
 
-if (UNIX AND NOT APPLE)
+if (APPLE)
+  set(CPACK_GENERATOR ZIP)   # make sure we don't overwrite 'make tarball''
+
+elseif (UNIX)
 
   set(PACKAGE_DEPS opencpn)
   # autogenerate additional dependency information

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -69,6 +69,12 @@ function (tarball_target)
     TARGET tarball-install
     COMMAND ${_install_cmd}
   )
+  add_custom_target(tarball-pkg)
+  add_custom_target(
+    TARGET tarball-pkg            # Move metadata in place.
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND cmake -E copy ${pkg_displayname}.xml app/files/metadata.xml
+  )
   add_custom_target(tarball-finish)
   add_custom_command(
     TARGET tarball-finish     # Change top-level directory name
@@ -88,7 +94,8 @@ function (tarball_target)
   add_dependencies(tarball-build tarball-conf)
   add_dependencies(tarball-install tarball-build)
   add_dependencies(tarball-finish tarball-install)
-  add_dependencies(tarball-tar tarball-finish)
+  add_dependencies(tarball-pkg tarball-finish)
+  add_dependencies(tarball-tar tarball-pkg)
 
   add_custom_target(tarball)
   add_dependencies(tarball tarball-tar)


### PR DESCRIPTION
Seems like a strange rebasing error. Re-adding one part which definitely has been with us before.

Thanks for good bug report which made it possible to nail down the error in no time.

You can check the tarball yourself by downloading it, expand it and look for the file metadata.xml which lives in the top directory