### PR TITLE
macos wxWidgets link issues

### DIFF
--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -52,3 +52,12 @@ if (${BUILD_TYPE} STREQUAL "tarball" OR ${BUILD_TYPE} STREQUAL "flatpak")
           RENAME metadata.xml
   )
 endif()
+
+# On macos, fix paths which points to the build environment, make sure they
+# refers to runtime locations
+if (${BUILD_TYPE} STREQUAL "tarball" AND APPLE)
+  install(CODE
+    "execute_process(
+      COMMAND bash -c ${PROJECT_SOURCE_DIR}/cmake/fix-macos-libs.sh)"
+  )
+endif()

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -7,7 +7,7 @@ set(wxWidgets_USE_DEBUG OFF)
 set(wxWidgets_USE_UNICODE ON)
 set(wxWidgets_USE_UNIVERSAL OFF)
 set(wxWidgets_USE_STATIC OFF)
-if (NOT QT_ANDROID AND NOT DEFINED wxWidgets_USE_FILE)
+if (NOT QT_ANDROID)
   # QT_ANDROID is a cross-build, so the native FIND_PACKAGE(OpenGL) is
   # not useful.
   find_package(OpenGL)

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -24,11 +24,9 @@ if (NOT QT_ANDROID)
   set(_LIBS base core net xml html adv ${GL_LIB})
   find_package(wxWidgets COMPONENTS ${_LIBS} REQUIRED)
   include(${wxWidgets_USE_FILE})
-endif ()
-
-if (NOT APPLE)
   target_link_libraries(${PACKAGE_NAME} ${wxWidgets_LIBRARIES})
 endif ()
+
 
 if (MINGW)
   target_link_libraries(${PACKAGE_NAME} ${OPENGL_LIBRARIES})

--- a/cmake/fix-macos-libs.sh
+++ b/cmake/fix-macos-libs.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+readonly RUNTIME_PATH="/Applications/OpenCPN.app/Contents/Frameworks"
+
+dylib=$(find app/files -name '*.dylib')
+
+for lib in $(otool -L $dylib | grep wx | awk '{print $1}'); do
+    libdir=${lib%/*}
+    if [ "$libdir" = "$lib" ]; then
+        continue
+    elif [ "$libdir" != "$RUNTIME_PATH" ]; then
+        newlib=$(echo $lib | sed "s|$libdir|$RUNTIME_PATH|")
+        install_name_tool -change $lib $newlib $dylib
+    fi
+done
+echo "Revised library paths:"
+otool -L $dylib | grep wx
+


### PR DESCRIPTION
The macos library linkage to wxWidgets is broken: cmake uses absolute library paths, but the bulid library paths does not match the runtime paths -> plugin does mnot link correctly to wxWidgets in runtime.

Add a build step which changes any wxWidgets library path to the correct runtime dir /Applications/OpenCPN.app/Contents/Frameworks using the install_name tool. Seems that macos a  tool specifically designed for this purpose. One might wonder why...