### PR TITLE
Ubuntu: fix gtk3 builds (#72)

### DIFF
--- a/ci/git-push
+++ b/ci/git-push
@@ -56,8 +56,13 @@ def get_password():
 def private_key_setup(ci, user, password): 
     """ Decrypt ssh key and setup up GIT_SSH_COMMAND in environment. """
 
-    with open(os.path.join(ci, user + ".enc"), 'r') as f:
-        encrypted = f.read()
+    try: 
+        with open(os.path.join(ci, user + ".enc"), 'r') as f:
+            encrypted = f.read()
+    except FileNotFoundError:
+        print("No private key found, cannot push metadata to git repo.")
+        print("See the file README-git.md for more.")
+        sys.exit(0)
     decrypted = decrypt1(encrypted.encode(), password.encode())
     with open(os.path.join(ci, user ), 'wb') as f:
         f.write(decrypted)

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -70,10 +70,19 @@ string(STRIP "${PKG_TARGET}" PKG_TARGET)
 string(TOLOWER "${PKG_TARGET}" PKG_TARGET)
 string(STRIP "${PKG_TARGET_VERSION}" PKG_TARGET_VERSION)
 string(TOLOWER "${PKG_TARGET_VERSION}" PKG_TARGET_VERSION)
-if (NOT DEFINED wxWidgets_LIBRARIES)
-  message(STATUS "PluginSetup: Not configuring ubuntu gtk3 target")
-elseif ("${wxWidgets_LIBRARIES}" MATCHES "gtk3u" 
-        AND PKG_TARGET STREQUAL "ubuntu"
-)
-  set(PKG_TARGET "${PKG_TARGET}-gtk3")
+
+if (PKG_TARGET STREQUAL "ubuntu")
+  find_program(_WX_CONFIG_PROG NAMES $ENV{WX_CONFIG} wx-config )
+  if (_WX_CONFIG_PROG)
+    execute_process(
+      COMMAND ${_WX_CONFIG_PROG} --selected-config
+      OUTPUT_VARIABLE _WX_SELECTED_CONFIG
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (_WX_SELECTED_CONFIG MATCHES gtk3)
+      set(PKG_TARGET ubuntu-gtk3)
+    endif ()
+  else ()
+    message(WARNING "Cannot locate wx-config utility")
+  endif ()
 endif ()


### PR DESCRIPTION
#72 is at least about the fact that gtk3 builds are not marked as such, using the same target as gtk2. This should be fixed by this PR. Whether this is  enough to actually fully resolve #72 remains to be investigated.

Also: minor cleanup in git-push, making a clean exit if there is no private key (i. e., the new-credentials program hasn't been run). 