### PR TITLE
cmake: Respect wxWidgets_CONFIG_EXECUTABLE command line variable.

### DIFF
--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -5,7 +5,10 @@
 #
 
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
-    echo 'Warning: $CLOUDSMITH_API_KEY is not available, upload will fail.'
+    echo 'Warning: $CLOUDSMITH_API_KEY is not available, giving up.'
+    echo 'Metadata: @pkg_displayname@.xml'
+    echo 'Tarball:  @pkg_tarname@.tar.gz'
+    exit 0
 else
     echo "Using CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY:0:4}..."
 fi

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -72,7 +72,11 @@ string(STRIP "${PKG_TARGET_VERSION}" PKG_TARGET_VERSION)
 string(TOLOWER "${PKG_TARGET_VERSION}" PKG_TARGET_VERSION)
 
 if (PKG_TARGET STREQUAL "ubuntu")
-  find_program(_WX_CONFIG_PROG NAMES $ENV{WX_CONFIG} wx-config )
+  if (DEFINED wxWidgets_CONFIG_EXECUTABLE)
+    set(_WX_CONFIG_PROG ${wxWidgets_CONFIG_EXECUTABLE})
+  else ()
+    find_program(_WX_CONFIG_PROG NAMES $ENV{WX_CONFIG} wx-config )
+  endif ()
   if (_WX_CONFIG_PROG)
     execute_process(
       COMMAND ${_WX_CONFIG_PROG} --selected-config


### PR DESCRIPTION
As heading says: If user sets wxWidgets_CONFIG_EXECUTABLE  on the cmake command line it must be respected