### PR TITLE
Don't fail hard on missing deployment keys (#69).

### DIFF
--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -5,7 +5,10 @@
 #
 
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
-    echo 'Warning: $CLOUDSMITH_API_KEY is not available, upload will fail.'
+    echo 'Warning: $CLOUDSMITH_API_KEY is not available, giving up.'
+    echo 'Metadata: @pkg_displayname@.xml'
+    echo 'Tarball:  @pkg_tarname@.tar.gz'
+    exit 0
 else
     echo "Using CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY:0:4}..."
 fi


### PR DESCRIPTION
If the cloudsmith keys are missing, make a clean exit with
warning message instead of a hard failure.

Closes: #69.