### PR TITLE
Add major.minor to build ids (#68).

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -56,7 +56,10 @@ endif ()
 set(pkg_semver "${PROJECT_VERSION}+${_build_id}.${_gitversion}")
 
 # pkg_displayname: Used for xml metadata and GUI name
-set(pkg_displayname "${PLUGIN_API_NAME}-${PKG_TARGET}-${PKG_TARGET_VERSION}")
+string(CONCAT pkg_displayname
+  "${PLUGIN_API_NAME}-${VERSION_MAJOR}.${VERSION_MINOR}"
+  "-${PKG_TARGET}-${PKG_TARGET_VERSION}"
+)
 
 # pkg_tarname: Tarball basename
 string(CONCAT pkg_tarname 


### PR DESCRIPTION
Creates tarballs and metadata named like ShipDriver-2.5-ubuntu-16.04. 

The major-minor spec is the compatibility level - as long as they the same the different versions are compatible. The complete version, including git commit, is available in the tarball name and in the Cloudsmith metadata (very visible when listing builds), so adding this also to the main name will probably just obscure things.

Closes: #68