### PR TITLE
build: Make builds verbose (#70).

### DIFF
--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -18,7 +18,7 @@ if [ -n "$BUILD_GTK3" ]; then
 fi
 
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-make tarball
+make VERBOSE=1 tarball
 
 sudo apt-get install python3-pip python3-setuptools
 sudo python3 -m pip install -q cloudsmith-cli

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -34,7 +34,7 @@ sed -i '/^runtime-version/s/:.*/: stable/' \
 
 mkdir build; cd build
 cmake  ..
-make flatpak
+make VERBOSE=1 flatpak
 
 # Restore file so the cache checksumming is ok.
 cp ../flatpak.yaml.bak org.opencpn.OpenCPN.Plugin.shipdriver.yaml

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -26,7 +26,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX="/" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
-make tarball
+make VERBOSE=1 tarball
 
 wget -q http://opencpn.navnux.org/build_deps/Packages.dmg
 hdiutil attach Packages.dmg

--- a/ci/circleci-build-mingw.sh
+++ b/ci/circleci-build-mingw.sh
@@ -44,7 +44,7 @@ sudo dnf -q builddep  -y /project/mingw/fedora/opencpn-deps.spec
 cd /project
 rm -rf build; mkdir build; cd build
 cmake -DCMAKE_TOOLCHAIN_FILE=../mingw/fedora/toolchain.cmake ..
-make tarball
+make VERBOSE=1 tarball
 EOF
 
 # Run the build in docker

--- a/ci/circleci-build-raspbian-armhf.sh
+++ b/ci/circleci-build-raspbian-armhf.sh
@@ -41,7 +41,7 @@ sudo apt-get -y install --no-install-recommends \
 cd /ci-source
 rm -rf build; mkdir build; cd build
 cmake ..
-make tarball
+make VERBOSE=1 tarball
 EOF
 
 docker exec -ti \


### PR DESCRIPTION
As heading says: Make sure the builds are verbose to ease debugging.

Closes: #70