### PR TITLE
Fixes for broken links, changed python deps and what not.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ debian-steps: &debian-steps
     - checkout
     - run: ci/circleci-build-debian.sh
     - run: cd build; /bin/bash < upload.sh
-    - run: pip3 install cryptography
     - run: python3 ci/git-push
 
 jobs:
@@ -19,7 +18,6 @@ jobs:
       - checkout
       - run: ci/circleci-build-mingw.sh
       - run: cd build; /bin/bash < upload.sh
-      - run: pip3 install cryptography
       - run: python3 ci/git-push
 
   build-flatpak:
@@ -29,7 +27,6 @@ jobs:
       - OCPN_TARGET: flatpak
     steps:
       - checkout
-      - run: pyenv local 3.5.2
       - restore_cache:
           keys:
             - fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
@@ -39,7 +36,6 @@ jobs:
           paths:
             - /home/circleci/.local/share/flatpak/repo
       - run: cd build; /bin/bash < upload.sh
-      - run: pip3 install cryptography
       - run: python3 ci/git-push
 
   build-macos:
@@ -108,7 +104,6 @@ jobs:
       - checkout
       - run: ci/circleci-build-raspbian-armhf.sh
       - run: cd build; /bin/bash < upload.sh
-      - run: pip3 install cryptography
       - run: python3 ci/git-push
 
   build-armhf-buster:
@@ -120,7 +115,6 @@ jobs:
       - checkout
       - run: ci/circleci-build-raspbian-armhf.sh
       - run: cd build; /bin/bash < upload.sh
-      - run: pip3 install cryptography
       - run: python3 ci/git-push
 
 std-filters: &std-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
           key: macos-cache-v1-{{checksum "ci/circleci-build-macos.sh"}}
           paths:
             - /usr/local/Homebrew
+            - /usr/local/Caskroom
             - /usr/local/Cellar
             - /usr/local/lib
             - /usr/local/include

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
             - /usr/local/lib
             - /usr/local/include
       - run: cd build; /bin/bash < upload.sh
-      - run: pip3 install cryptography
       - run: python3 ci/git-push
 
   build-xenial:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,16 +37,16 @@ message(STATUS "Building: ${BUILD_TYPE}")
 
 
 # -------- Options ----------
-#
-#set(OCPN_TEST_REPO
-#    "opencpn/shipdriver-alpha"
-#    CACHE STRING "Default repository for untagged builds"
-#)
-#set(OCPN_BETA_REPO
-#    "opencpn/shipdriver-beta"
-#    CACHE STRING 
-#    "Default repository for tagged builds matching 'beta'"
-#)
+
+set(OCPN_TEST_REPO
+    "opencpn/shipdriver-alpha"
+    CACHE STRING "Default repository for untagged builds"
+)
+set(OCPN_BETA_REPO
+    "opencpn/shipdriver-beta"
+    CACHE STRING 
+    "Default repository for tagged builds matching 'beta'"
+)
 set(OCPN_RELEASE_REPO
     "opencpn/shipdriver-prod"
     CACHE STRING 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - choco install poedit
 
   # Download and unzip wxwidgets
-  - ps: Start-FileDownload http://opencpn.navnux.org/build_deps/wxWidgets-3.1.2.7z
+  - ps: Start-FileDownload https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -FileName wxWidgets-3.1.2.7z
   - cmd: 7z x wxWidgets-3.1.2.7z -o%WXWIN% > null
 
   # some debugging information

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,15 +50,18 @@ build_script:
   - cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
   - choco install git
+  - cmd: SET PATH=C:\Python38;C:\Python38-x64\Scripts;%PATH%
+  - py --version
   - py -m ensurepip
-  - py -m pip install -q setuptools
+  - py -m pip install --upgrade pip
+  - py -m pip install -q setuptools wheel
   - py -m pip install -q cloudsmith-cli
   - bash ./upload.sh
-  - PATH=C:\Python38;%PATH%
-  - python --version
-  - python -m pip install -q cryptography
-  - cd ..\ci
-  - python git-push
+    # Disabled, installing cryptography fails, see #88
+    # - choco install openssl.light
+    # - pip install cryptography
+    # - cd ..\ci
+    # - py git-push
 
 artifacts:
   - path: 'build\*.exe'

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -20,5 +20,9 @@ fi
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 tarball
 
-sudo apt-get install python3-pip python3-setuptools
-sudo python3 -m pip install -q cloudsmith-cli
+sudo apt-get install \
+    python3-pip python3-setuptools python3-dev python3-wheel \
+    build-essential libssl-dev libffi-dev 
+
+pip3 install --user --upgrade pip
+pip3 install --user -q cloudsmith-cli

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -24,5 +24,6 @@ sudo apt-get install \
     python3-pip python3-setuptools python3-dev python3-wheel \
     build-essential libssl-dev libffi-dev 
 
-pip3 install --user --upgrade pip
-pip3 install --user -q cloudsmith-cli
+python3 -m pip install --user --upgrade pip
+python3 -m pip install --user -q cloudsmith-cli
+python3 -m pip install --user -q cryptography

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -31,6 +31,10 @@ flatpak install --user -y flathub org.freedesktop.Sdk//18.08  >/dev/null
 sed -i '/^runtime-version/s/:.*/: stable/' \
     flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
 
+# The flatpak checksumming needs python3:
+pyenv local $(pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1)
+cp .python-version $HOME
+
 mkdir build; cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 flatpak
@@ -44,5 +48,12 @@ git checkout ../flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
 echo -n "Waiting for apt_daily lock..."
 sudo flock /var/lib/apt/daily_lock echo done
 
-pyenv local $(pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1)
-pip3 install cloudsmith-cli
+# Install cloudsmith, requiered by upload script
+python3 -m pip install --user --upgrade pip
+python3 -m pip install --user cloudsmith-cli
+
+# Required by git-push
+python3 -m pip install --user cryptography
+
+# python install scripts in ~/.local/bin:
+echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -28,7 +28,6 @@ flatpak remote-add --user --if-not-exists flathub \
     https://flathub.org/repo/flathub.flatpakrepo
 flatpak install --user -y flathub org.opencpn.OpenCPN > /dev/null
 flatpak install --user -y flathub org.freedesktop.Sdk//18.08  >/dev/null
-cp flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml flatpak.yaml.bak
 sed -i '/^runtime-version/s/:.*/: stable/' \
     flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
 
@@ -37,7 +36,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 flatpak
 
 # Restore file so the cache checksumming is ok.
-cp ../flatpak.yaml.bak org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+git checkout ../flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
 
 # Wait for apt-daily to complete, install cloudsmith-cli required by upload.sh.
 # apt-daily should not restart, it's masked.

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -15,15 +15,16 @@ for pkg in cairo cmake gettext libarchive libexif python wget; do
     brew link --overwrite $pkg || brew install $pkg
 done
 
-wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
-tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
+wget -q https://download.opencpn.org/s/rwoCNGzx6G34tbC/download \
+    -O /tmp/wx312B_opencpn50_macos109.tar.xz
+tar -C /tmp -xJf /tmp/wx312B_opencpn50_macos109.tar.xz 
 
 export MACOSX_DEPLOYMENT_TARGET=10.9
 
 rm -rf build && mkdir build && cd build
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config \
+  -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312B_opencpn50_macos109/bin/wx-config \
   -DCMAKE_INSTALL_PREFIX="/" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -8,12 +8,28 @@ set -xe
 
 #
 # Check if the cache is with us. If not, re-install brew.
-brew list --versions libexif || brew update-reset
+brew list --versions libexif || {
+    brew update-reset
+    # As indicated by warning message in CircleCI build log:
+    git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" \
+        fetch --unshallow
+    git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask" \
+        fetch --unshallow
+}
 
 for pkg in cairo cmake gettext libarchive libexif python wget; do
     brew list --versions $pkg || brew install $pkg || brew install $pkg || :
     brew link --overwrite $pkg || brew install $pkg
 done
+
+if brew list --cask --versions packages; then
+    version=$(pkg_version packages '--cask')
+    sudo installer \
+        -pkg /usr/local/Caskroom/packages/$version/packages/Packages.pkg \
+        -target /
+else
+    brew install --cask packages
+fi
 
 wget -q https://download.opencpn.org/s/rwoCNGzx6G34tbC/download \
     -O /tmp/wx312B_opencpn50_macos109.tar.xz

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -30,9 +30,6 @@ cmake \
   ..
 make -j $(sysctl -n hw.physicalcpu) VERBOSE=1 tarball
 
-wget -q http://opencpn.navnux.org/build_deps/Packages.dmg
-hdiutil attach Packages.dmg
-sudo installer -pkg "/Volumes/Packages 1.2.5/Install Packages.pkg" -target "/"
 make create-pkg
 
 # Install cloudsmith needed by upload script

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -34,3 +34,6 @@ make create-pkg
 
 # Install cloudsmith needed by upload script
 pip3 install cloudsmith-cli
+
+# Required by git-push
+pip3 install cryptography

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -49,7 +49,13 @@ make -j $(sysctl -n hw.physicalcpu) VERBOSE=1 tarball
 make create-pkg
 
 # Install cloudsmith needed by upload script
-pip3 install cloudsmith-cli
+python3 -m pip install --user cloudsmith-cli
 
 # Required by git-push
-pip3 install cryptography
+python3 -m pip install --user cryptography
+
+# python3 installs in odd place not on PATH:
+pyvers=$(python3 --version | awk '{ print $2 }')
+pyvers=$(echo $pyvers | sed -E 's/[\.][0-9]+$//')    # drop last .z in x.y.z
+echo "export PATH=\$PATH:/Users/distiller/Library/Python/$pyvers/bin" \
+    >> ~/.uploadrc

--- a/ci/circleci-build-mingw.sh
+++ b/ci/circleci-build-mingw.sh
@@ -26,6 +26,7 @@ docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v "$(pwd):/project:rw" \
     -e "CLOUDSMITH_STABLE_REPO=$CLOUDSMITH_STABLE_REPO" \
+    -e "CLOUDSMITH_BETA_REPO=$CLOUDSMITH_BETA_REPO" \
     -e "CLOUDSMITH_UNSTABLE_REPO=$CLOUDSMITH_UNSTABLE_REPO" \
     -e "CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM" \
     fedora:33   /bin/bash

--- a/ci/circleci-build-mingw.sh
+++ b/ci/circleci-build-mingw.sh
@@ -61,5 +61,12 @@ echo -n "Waiting for apt_daily lock..."
 sudo flock /var/lib/apt/daily_lock echo done
 
 # Select latest available python, install cloudsmith required by upload script
-pyenv local $(pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1)
-pip3 install cloudsmith-cli
+pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
+    > $HOME/.python-version
+python3 -m pip install --user cloudsmith-cli
+
+# Required by git-push
+python3 -m pip install --user cryptography
+
+# python install scripts in ~/.local/bin:
+echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc

--- a/ci/circleci-build-raspbian-armhf.sh
+++ b/ci/circleci-build-raspbian-armhf.sh
@@ -19,6 +19,7 @@ docker run --privileged -d -ti \
     -e "container=docker" \
     -e "OCPN_TARGET=$OCPN_TARGET" \
     -e "CLOUDSMITH_STABLE_REPO=$CLOUDSMITH_STABLE_REPO" \
+    -e "CLOUDSMITH_BETA_REPO=$CLOUDSMITH_BETA_REPO" \
     -e "CLOUDSMITH_UNSTABLE_REPO=$CLOUDSMITH_UNSTABLE_REPO" \
     -e "CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM" \
     -v $(pwd):/ci-source:rw \

--- a/ci/circleci-build-raspbian-armhf.sh
+++ b/ci/circleci-build-raspbian-armhf.sh
@@ -56,6 +56,11 @@ rm -f build.sh
 
 
 # Install cloudsmith-cli,  required by upload.sh.
+pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
+    > $HOME/.python-version
+python3 -m pip install --upgrade pip
+python3 -m pip install --user cloudsmith-cli
+python3 -m pip install --user cryptography
 
-pyenv local $(pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1)
-pip3 install --user cloudsmith-cli
+# python install scripts in ~/.local/bin:
+echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc

--- a/ci/travis-build-raspbian-armhf.sh
+++ b/ci/travis-build-raspbian-armhf.sh
@@ -51,4 +51,12 @@ rm -f build.sh
 # Install cloudsmith-cli, required by upload.sh
 sudo apt-get -qq update
 sudo apt -q install python3-pip python3-setuptools
-pip3 install -q cloudsmith-cli
+
+pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
+    > $HOME/.python-version
+python3 -m pip install --upgrade pip
+python3 -m pip install --user -q cloudsmith-cli
+python3 -m pip install --user -q cryptography
+
+# python install scripts in ~/.local/bin:
+echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.bashrc

--- a/ci/travis-build-raspbian-armhf.sh
+++ b/ci/travis-build-raspbian-armhf.sh
@@ -17,6 +17,7 @@ docker run --privileged -d -ti \
       -v $(pwd):/ci-source:rw \
       -e "container=docker" \
       -e "CLOUDSMITH_STABLE_REPO=$CLOUDSMITH_STABLE_REPO" \
+      -e "CLOUDSMITH_BETA_REPO=$CLOUDSMITH_BETA_REPO" \
       -e "CLOUDSMITH_UNSTABLE_REPO=$CLOUDSMITH_UNSTABLE_REPO" \
       -e "TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER" \
       $DOCKER_IMAGE /bin/bash

--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -7,21 +7,24 @@
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Warning: $CLOUDSMITH_API_KEY is not available, giving up.'
     echo 'Metadata: @pkg_displayname@.xml'
-    echo 'Tarball:  @pkg_tarname@.tar.gz'
+    echo 'Tarball: @pkg_tarname@.tar.gz'
+    echo 'Version: @pkg_semver@'
     exit 0
 else
     echo "Using CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY:0:4}..."
 fi
 
+if [ -f ~/.uploadrc ]; then source ~/.uploadrc; fi
 set -xe
 
-@pkg_python@ -m cloudsmith_cli push raw --no-wait-for-sync \
+
+cloudsmith push raw --no-wait-for-sync \
     --name @pkg_displayname@-metadata \
     --version @pkg_semver@ \
     --summary "Plugin metadata for automatic installation" \
     @pkg_repo@ @pkg_displayname@.xml
 
-@pkg_python@ -m cloudsmith_cli push raw --no-wait-for-sync \
+cloudsmith push raw --no-wait-for-sync \
     --name @pkg_displayname@-tarball \
     --version @pkg_semver@ \
     --summary "Plugin tarball for automatic installation" \

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -100,9 +100,9 @@ string(CONCAT pkg_tarball_url
 find_program(PY_WRAPPER py) # (at least) appveyor build machines
 find_program(PYTHON3 python3)
 if (PY_WRAPPER)
-  set(pkg_python py)
+  set(pkg_python ${PY_WRAPPER})
 elseif (PYTHON3)
-  set(pkg_python python3)
+  set(pkg_python ${PYTHON3})
 else ()
   set(pkg_python python)
 endif ()


### PR DESCRIPTION
Too many build fixes for a package meant to stabilize. Mostly due to changing environment (?)

  - A few errors spotted while reading the code
  - The changed download links: https://github.com/OpenCPN/OpenCPN/issues/2125
  - Handle changes in how brew downloads packages, in particular a very expensive need to perform perforn  _git fetch --unshallow_  on brew clones
  - Handle changes how the cloudsmith python installation behaves, in particular use the script which is the official entrypoint rather than _python3 -m cloudsmith_cli_
  - Handle scripts installed in locations not in $PATH using a .uploadrc file.
  - Streamline the python cryptography installation, use --user which avoids problem when installing system-wide. 
  - Fix a bug where the version selected by _pyenv local_  wasn't found and used in other parts of scripts.

#88 is still with us, so windows builds are not replicated to the git repo.  Otherwise, it builds fine and is IMHO ready to merge. Buld logs a  [circleci](https://app.circleci.com/pipelines/github/leamas/shipdriver_pi/575/workflows/21c587eb-8272-48c7-bb51-446bf0348b0d) and [appveyor](https://ci.appveyor.com/project/leamas/shipdriver-pi), (not a direct link)