### PR TITLE
ci: macos: Fix missing bash function (#88).

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -6,6 +6,9 @@
 
 set -xe
 
+# Return latest version of $1, optiomally using option $2
+pkg_version() { brew list --versions $2 $1 | tail -1 | awk '{print $2}'; }
+
 #
 # Check if the cache is with us. If not, re-install brew.
 brew list --versions libexif || {


### PR DESCRIPTION
Nasty error, only shows up if cache is invalidated i. e., after changes
in ci/circleci-build-macos.sh. This means while things built fine by me, they failed by you.

This *should* fix  the macos issue (knock, knock...)