### PR TITLE
Appveyor no bash (#93)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,12 @@ configure_file(
   ${CMAKE_SOURCE_DIR}/ci/upload.sh.in ${CMAKE_BINARY_DIR}/upload.sh
   @ONLY
 )
+configure_file(
+  # The cloudsmith upload script, windows bat file.
+  ${CMAKE_SOURCE_DIR}/ci/upload.bat.in ${CMAKE_BINARY_DIR}/upload.bat
+  @ONLY
+)
+
 
 set(checksum "@checksum@")
 configure_file(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_build:
   # Unless removed, this interferes with the 32-bit python installation
   - rmdir /Q /S C:\Python38-x64
 
-  # python stuff required by upload.sh and git-push
+  # python stuff required by upload.bat and git-push
   - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
   - py --version
   - py -m ensurepip
@@ -50,8 +50,6 @@ before_build:
   - pip install -q setuptools wheel
   - pip install -q cloudsmith-cli
   - pip install -q cryptography
-  # Required to run upload.sh
-  - choco install git
 
 build_script:
   - mkdir build
@@ -59,8 +57,7 @@ build_script:
   - cmake -T v141_xp ..
   - cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
-  - choco install git
-  - bash ./upload.sh
-  - cd ..\ci
-  - py git-push
+  - cmd: upload.bat
+  - py ..\ci\git-push
+
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,27 +39,24 @@ install:
   #- cmd: nmake -f makefile.vc BUILD=debug SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
 
 before_build:
-  # Unless removed, these interferes with the 32-bit python installation
-  - rmdir /Q /S C:\Python26-x64
-  - rmdir /Q /S C:\Python27-x64
-  - rmdir /Q /S C:\Python33-x64
-  - rmdir /Q /S C:\Python34-x64
-  - rmdir /Q /S C:\Python35-x64
-  - rmdir /Q /S C:\Python36-x64
-  - rmdir /Q /S C:\Python37-x64
+  # Unless removed, this interferes with the 32-bit python installation
   - rmdir /Q /S C:\Python38-x64
+
+  # python stuff required by upload.sh and git-push
   - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
   - py --version
   - py -m ensurepip
   - py -m pip install --upgrade pip
-  - py -m pip install -q setuptools wheel
-  - py -m pip install -q cloudsmith-cli
-  - pip install cryptography
+  - pip install -q setuptools wheel
+  - pip install -q cloudsmith-cli
+  - pip install -q cryptography
+  # Required to run upload.sh
+  - choco install git
+
+build_script:
   - mkdir build
   - cd build
   - cmake -T v141_xp ..
-
-build_script:
   - cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
   - choco install git

--- a/ci/upload.bat.in
+++ b/ci/upload.bat.in
@@ -1,0 +1,27 @@
+
+rem
+rem  Upload the .tar.gz and .xml artifacts to cloudsmith
+rem
+
+echo OFF
+if "%CLOUDSMITH_API_KEY%" == "" (
+    echo 'Warning: CLOUDSMITH_API_KEY is not available, giving up.'
+    echo 'Metadata: @pkg_displayname@.xml'
+    echo 'Tarball: @pkg_tarname@.tar.gz'
+    echo 'Version: @pkg_semver@'
+    exit 0
+)
+echo Using CLOUDSMITH_API_KEY: %CLOUDSMITH_API_KEY:~,4%%...
+echo ON
+
+cloudsmith push raw --no-wait-for-sync ^
+    --name @pkg_displayname@-metadata ^
+    --version @pkg_semver@ ^
+    --summary "Plugin metadata for automatic installation" ^
+    @pkg_repo@ @pkg_displayname@.xml
+
+cloudsmith push raw --no-wait-for-sync ^
+    --name @pkg_displayname@-tarball ^
+    --version @pkg_semver@ ^
+    --summary "Plugin tarball for automatic installation" ^
+    @pkg_repo@ @pkg_tarname@.tar.gz

--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -10,13 +10,12 @@ if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Tarball: @pkg_tarname@.tar.gz'
     echo 'Version: @pkg_semver@'
     exit 0
-else
-    echo "Using CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY:0:4}..."
 fi
+
+echo "Using CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY:0:4}..."
 
 if [ -f ~/.uploadrc ]; then source ~/.uploadrc; fi
 set -xe
-
 
 cloudsmith push raw --no-wait-for-sync \
     --name @pkg_displayname@-metadata \


### PR DESCRIPTION
Use a windows bat-file instead of a bash script on windows, and drop the git-bash dependency.

Closes: #93 