### PR TITLE
cmake: Clean up messy targets definitions (#95)

### DIFF
--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -83,8 +83,8 @@ if (CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
     )
     install(CODE
       "execute_process(
-        COMMAND ${STRIP_UTIL} app/files/${_striplib}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ${STRIP_UTIL} app/files/${_striplib}
       )"
     )
   endif ()

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -41,10 +41,10 @@ else ()
       cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
 endif ()
 
-if (WIN32 AND NOT MINGW)
-  set(_mvdir rename)
-else ()
+if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 12)
   set(_mvdir mv)
+else ()
+  set(_mvdir cmake -E rename)
 endif ()
 
 # Command to compute sha256 checksum

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -40,7 +40,8 @@ else ()
   set(_build_target_cmd
       cmake --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target
   )
-  set(_install_cmd cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
+  set(_install_cmd
+      cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
 endif ()
 
 if (WIN32 AND NOT MINGW)
@@ -69,76 +70,44 @@ set(_cs_script "
     ${CMAKE_BINARY_DIR}/${pkg_displayname}.xml.in
     ${CMAKE_BINARY_DIR}/${pkg_displayname}.xml
     @ONLY
-)")
+  )
+")
 file(WRITE "${CMAKE_BINARY_DIR}/checksum.cmake" ${_cs_script})
-
-
-# General post-process targets. Functions with a name parameter are used to
-# break dependency chains.
-#
-function(topdir_target target_name)
-  add_custom_target(${target_name})
-  add_custom_command(
-    TARGET ${target_name}     # Change top-level directory name
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/app
-    COMMAND ${_mvdir} files ${pkg_displayname}
-  )
-endfunction ()
-
-function(tar_target target_name)
-  add_custom_target(${target_name})
-  add_custom_command(
-    TARGET ${target_name}     # Build the tarball
-    WORKING_DIRECTORY  ${CMAKE_BINARY_DIR}/app
-    COMMAND
-      cmake -E
-      tar -czf ../${pkg_tarname}.tar.gz --format=gnutar ${pkg_displayname}
-    VERBATIM
-    COMMENT "Building ${pkg_tarname}.tar.gz"
-  )
-endfunction ()
-
-function(cs_target target_name)
-  add_custom_target(${target_name})
-  add_custom_command(
-    TARGET ${target_name}      # Compute checksum
-    COMMAND cmake -P ${CMAKE_BINARY_DIR}/checksum.cmake
-    VERBATIM
-    COMMENT "Computing checksum in ${pkg_displayname}.xml"
-  )
-endfunction ()
 
 function (tarball_target)
 
-  # tarball target setup
-  #
   add_custom_target(tarball-conf)
   add_custom_command(
     TARGET tarball-conf
     COMMAND cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/app/files
             -DBUILD_TYPE:STRING=tarball ${CMAKE_BINARY_DIR}
   )
-  add_custom_target(tarball-build)
-  add_custom_command(
-    TARGET tarball-build
-    COMMAND ${_build_cmd}
-  )
-  add_custom_target(tarball-install)
-  add_custom_command(
-    TARGET tarball-install
-    COMMAND ${_install_cmd}
-  )
-  topdir_target("tarball-topdir")
-  tar_target("tarball-tar")
-  cs_target("tarball-cs")
-  add_dependencies(tarball-build tarball-conf)
-  add_dependencies(tarball-install tarball-build)
-  add_dependencies(tarball-topdir tarball-install)
-  add_dependencies(tarball-tar tarball-topdir)
-  add_dependencies(tarball-cs tarball-tar)
+  set(_tarball_script "
+    execute_process(COMMAND ${_build_cmd})
+    execute_process(COMMAND ${_install_cmd})
+    execute_process(
+      WORKING_DIRECTORY  ${CMAKE_BINARY_DIR}/app
+      COMMAND ${_mvdir} files ${pkg_displayname}
+    )
+    execute_process(
+      WORKING_DIRECTORY  ${CMAKE_BINARY_DIR}/app
+      COMMAND
+        cmake -E
+        tar -czf ../${pkg_tarname}.tar.gz --format=gnutar ${pkg_displayname}
+    )
+    message(STATUS \"Creating tarball ${pkg_tarname}.tar.gz\")
 
+    execute_process( COMMAND cmake -P ${CMAKE_BINARY_DIR}/checksum.cmake)
+    message(STATUS \"Computing checksum in ${pkg_displayname}.xml\")
+  ")
+  file(WRITE "${CMAKE_BINARY_DIR}/build_tarball.cmake" "${_tarball_script}")
   add_custom_target(tarball)
-  add_dependencies(tarball tarball-cs)
+  add_custom_command(
+    TARGET tarball      # Compute checksum
+    COMMAND cmake -P ${CMAKE_BINARY_DIR}/build_tarball.cmake
+    VERBATIM
+  )
+  add_dependencies(tarball tarball-conf)
 endfunction ()
 
 function (flatpak_target manifest)
@@ -176,7 +145,7 @@ function (flatpak_target manifest)
     )
     message(STATUS \"Computing checksum in ${pkg_displayname}.xml\")
   ")
-  file(WRITE "${CMAKE_BINARY_DIR}/build_flatpak.cmake" ${_fp_script})
+  file(WRITE "${CMAKE_BINARY_DIR}/build_flatpak.cmake" "${_fp_script}")
   add_custom_target(flatpak)
   add_custom_command(
     TARGET flatpak      # Compute checksum

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -26,10 +26,7 @@ endif ()
 if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 10)
   set(_build_cmd make -j2)
 else ()
-  set(_build_cmd
-    cmake --build ${CMAKE_BINARY_DIR} ${_parallel_cmake_opt}
-    --config $<CONFIG>
-  )
+  set(_build_cmd cmake --build ${CMAKE_BINARY_DIR} ${_parallel_cmake_opt})
 endif ()
 
 # Set up _build_target_cmd and _install_cmd

--- a/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
@@ -26,7 +26,6 @@ modules:
           cxxflags: -DFLATPAK -O3
           cflags: -DFLATPAK -O3
           # The flatpak-builder default CFLAGS adds -g
-          strip: true
       sources:
           - type: git
             url: ..


### PR DESCRIPTION
Use a cmake batch file instead of trllions of targets to get a sequential flow.

Closes: #95