### PR TITLE
Add .cmake-format formatting options file.

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,27 +1,241 @@
-additional_commands:
-  foo:
-    flags:
-    - BAR
-    - BAZ
-    kwargs:
-      DEPENDS: '*'
-      HEADERS: '*'
-      SOURCES: '*'
-always_wrap: []
-bullet_char: '-'
-command_case: lower
-dangle_parens: true
-emit_byteorder_mark: false
-enable_markup: true
-enum_char: .
-#fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
-first_comment_is_literal: false
-keyword_case: unchanged
-line_ending: unix
-line_width: 80
-literal_comment_pattern: null
-per_command: {}
-#ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
-separate_ctrl_name_with_space: true
-separate_fn_name_with_space: false
-tab_size: 2
+#
+#  Options for cmake-format, https://github.com/cheshirekow/cmake_format
+#
+#  See: https://github.com/leamas/OpenCPN/wiki/Plugin-adaptation
+#
+_help_parse: Options affecting listfile parsing
+parse:
+  _help_additional_commands:
+  - Specify structure for custom cmake functions
+  _help_override_spec:
+  - Override configurations per-command where available
+  override_spec: {}
+  _help_vartags:
+  - Specify variable tags.
+  vartags: []
+  _help_proptags:
+  - Specify property tags.
+  proptags: []
+_help_format: Options affecting formatting.
+format:
+  _help_disable:
+  - Disable formatting entirely, making cmake-format a no-op
+  disable: false
+  _help_line_width:
+  - How wide to allow formatted cmake files
+  line_width: 80
+  _help_tab_size:
+  - How many spaces to tab for indent
+  tab_size: 2
+  _help_use_tabchars:
+  - If true, lines are indented using tab characters (utf-8
+  - 0x09) instead of <tab_size> space characters (utf-8 0x20).
+  - In cases where the layout would require a fractional tab
+  - character, the behavior of the  fractional indentation is
+  - governed by <fractional_tab_policy>
+  use_tabchars: false
+  _help_fractional_tab_policy:
+  - If <use_tabchars> is True, then the value of this variable
+  - indicates how fractional indentions are handled during
+  - whitespace replacement. If set to 'use-space', fractional
+  - indentation is left as spaces (utf-8 0x20). If set to
+  - '`round-up` fractional indentation is replaced with a single'
+  - tab character (utf-8 0x09) effectively shifting the column
+  - to the next tabstop
+  fractional_tab_policy: use-space
+  _help_max_subgroups_hwrap:
+  - If an argument group contains more than this many sub-groups
+  - (parg or kwarg groups) then force it to a vertical layout.
+  max_subgroups_hwrap: 2
+  _help_max_pargs_hwrap:
+  - If a positional argument group contains more than this many
+  - arguments, then force it to a vertical layout.
+  max_pargs_hwrap: 8
+  _help_max_rows_cmdline:
+  - If a cmdline positional group consumes more than this many
+  - lines without nesting, then invalidate the layout (and nest)
+  max_rows_cmdline: 2
+  _help_separate_ctrl_name_with_space:
+  - If true, separate flow control names from their parentheses
+  - with a space
+  separate_ctrl_name_with_space: true
+  _help_separate_fn_name_with_space:
+  - If true, separate function names from parentheses with a
+  - space
+  separate_fn_name_with_space: false
+  _help_dangle_parens:
+  - If a statement is wrapped to more than one line, than dangle
+  - the closing parenthesis on its own line.
+  dangle_parens: true
+  _help_dangle_align:
+  - If the trailing parenthesis must be 'dangled' on its on
+  - 'line, then align it to this reference: `prefix`: the start'
+  - 'of the statement,  `prefix-indent`: the start of the'
+  - 'statement, plus one indentation  level, `child`: align to'
+  - the column of the arguments
+  dangle_align: prefix
+  _help_min_prefix_chars:
+  - If the statement spelling length (including space and
+  - parenthesis) is smaller than this amount, then force reject
+  - nested layouts.
+  min_prefix_chars: 4
+  _help_max_prefix_chars:
+  - If the statement spelling length (including space and
+  - parenthesis) is larger than the tab width by more than this
+  - amount, then force reject un-nested layouts.
+  max_prefix_chars: 10
+  _help_max_lines_hwrap:
+  - If a candidate layout is wrapped horizontally but it exceeds
+  - this many lines, then reject the layout.
+  max_lines_hwrap: 2
+  _help_line_ending:
+  - What style line endings to use in the output.
+  line_ending: unix
+  _help_command_case:
+  - Format command names consistently as 'lower' or 'upper' case
+  command_case: lower
+  _help_keyword_case:
+  - Format keywords consistently as 'lower' or 'upper' case
+  keyword_case: unchanged
+  _help_always_wrap:
+  - A list of command names which should always be wrapped
+  always_wrap: []
+  _help_enable_sort:
+  - If true, the argument lists which are known to be sortable
+  - will be sorted lexicographicall
+  enable_sort: true
+  _help_autosort:
+  - If true, the parsers may infer whether or not an argument
+  - list is sortable (without annotation).
+  autosort: false
+  _help_require_valid_layout:
+  - By default, if cmake-format cannot successfully fit
+  - everything into the desired linewidth it will apply the
+  - last, most agressive attempt that it made. If this flag is
+  - True, however, cmake-format will print error, exit with non-
+  - zero status code, and write-out nothing
+  require_valid_layout: false
+  _help_layout_passes:
+  - A dictionary mapping layout nodes to a list of wrap
+  - decisions. See the documentation for more information.
+  layout_passes: {}
+_help_markup: Options affecting comment reflow and formatting.
+markup:
+  _help_bullet_char:
+  - What character to use for bulleted lists
+  bullet_char: '-'
+  _help_enum_char:
+  - What character to use as punctuation after numerals in an
+  - enumerated list
+  enum_char: .
+  _help_first_comment_is_literal:
+  - If comment markup is enabled, don't reflow the first comment
+  - block in each listfile. Use this to preserve formatting of
+  - your copyright/license statements.
+  first_comment_is_literal: false
+  _help_literal_comment_pattern:
+  - If comment markup is enabled, don't reflow any comment block
+  - which matches this (regex) pattern. Default is `None`
+  - (disabled).
+  literal_comment_pattern: null
+  _help_fence_pattern:
+  - Regular expression to match preformat fences in comments
+  - default= ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+  fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
+  _help_ruler_pattern:
+  - Regular expression to match rulers in comments default=
+  - '``r''^\s*[^\w\s]{3}.*[^\w\s]{3}$''``'
+  ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
+  _help_explicit_trailing_pattern:
+  - If a comment line matches starts with this pattern then it
+  - is explicitly a trailing comment for the preceeding
+  - argument. Default is '#<'
+  explicit_trailing_pattern: '#<'
+  _help_hashruler_min_length:
+  - If a comment line starts with at least this many consecutive
+  - hash characters, then don't lstrip() them off. This allows
+  - for lazy hash rulers where the first hash char is not
+  - separated by space
+  hashruler_min_length: 10
+  _help_canonicalize_hashrulers:
+  - If true, then insert a space between the first hash char and
+  - remaining hash chars in a hash ruler, and normalize its
+  - length to fill the column
+  canonicalize_hashrulers: true
+  _help_enable_markup:
+  - enable comment markup parsing and reflow
+  enable_markup: true
+_help_lint: Options affecting the linter
+lint:
+  _help_disabled_codes:
+  - a list of lint codes to disable
+  disabled_codes: []
+  _help_function_pattern:
+  - regular expression pattern describing valid function names
+  function_pattern: '[0-9a-z_]+'
+  _help_macro_pattern:
+  - regular expression pattern describing valid macro names
+  macro_pattern: '[0-9A-Z_]+'
+  _help_global_var_pattern:
+  - regular expression pattern describing valid names for
+  - variables with global (cache) scope
+  global_var_pattern: '[A-Z][0-9A-Z_]+'
+  _help_internal_var_pattern:
+  - regular expression pattern describing valid names for
+  - variables with global scope (but internal semantic)
+  internal_var_pattern: _[A-Z][0-9A-Z_]+
+  _help_local_var_pattern:
+  - regular expression pattern describing valid names for
+  - variables with local scope
+  local_var_pattern: '[a-z][a-z0-9_]+'
+  _help_private_var_pattern:
+  - regular expression pattern describing valid names for
+  - privatedirectory variables
+  private_var_pattern: _[0-9a-z_]+
+  _help_public_var_pattern:
+  - regular expression pattern describing valid names for public
+  - directory variables
+  public_var_pattern: '[A-Z][0-9A-Z_]+'
+  _help_argument_var_pattern:
+  - regular expression pattern describing valid names for
+  - function/macro arguments and loop variables.
+  argument_var_pattern: '[a-z][a-z0-9_]+'
+  _help_keyword_pattern:
+  - regular expression pattern describing valid names for
+  - keywords used in functions or macros
+  keyword_pattern: '[A-Z][0-9A-Z_]+'
+  _help_max_conditionals_custom_parser:
+  - In the heuristic for C0201, how many conditionals to match
+  - within a loop in before considering the loop a parser.
+  max_conditionals_custom_parser: 2
+  _help_min_statement_spacing:
+  - Require at least this many newlines between statements
+  min_statement_spacing: 1
+  _help_max_statement_spacing:
+  - Require no more than this many newlines between statements
+  max_statement_spacing: 2
+  max_returns: 6
+  max_branches: 12
+  max_arguments: 5
+  max_localvars: 15
+  max_statements: 50
+_help_encode: Options affecting file encoding
+encode:
+  _help_emit_byteorder_mark:
+  - If true, emit the unicode byte-order mark (BOM) at the start
+  - of the file
+  emit_byteorder_mark: false
+  _help_input_encoding:
+  - Specify the encoding of the input file. Defaults to utf-8
+  input_encoding: utf-8
+  _help_output_encoding:
+  - Specify the encoding of the output file. Defaults to utf-8.
+  - Note that cmake only claims to support utf-8 so be careful
+  - when using anything else
+  output_encoding: utf-8
+_help_misc: Miscellaneous configurations options.
+misc:
+  _help_per_command:
+  - A dictionary containing any per-command configuration
+  - overrides. Currently only `command_case` is supported.
+  per_command: {}

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -1,6 +1,6 @@
 #
-# Add the primary build targets pkg, flatpak and tarball together
-# with helper targets.
+# Add the primary build targets pkg, flatpak and tarball together with helper
+# targets.
 #
 
 if (TARGET tarball-build)
@@ -34,11 +34,10 @@ if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 16)
   set(_build_target_cmd make)
   set(_install_cmd make install)
 else ()
-  set(_build_target_cmd
-      cmake --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target
+  set(_build_target_cmd cmake --build ${CMAKE_BINARY_DIR} --config $<CONFIG>
+                        --target
   )
-  set(_install_cmd
-      cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
+  set(_install_cmd cmake --install ${CMAKE_BINARY_DIR} --config $<CONFIG>)
 endif ()
 
 if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 12)
@@ -51,12 +50,13 @@ endif ()
 if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 10)
   set(_cs_command "${pkg_python} ${PROJECT_SOURCE_DIR}/ci/checksum.py")
 else ()
-  set(_cs_command "cmake -E sha256sum" )
+  set(_cs_command "cmake -E sha256sum")
 endif ()
 
 # Cmake batch file to compute and patch metadata checksum
 #
-set(_cs_script "
+set(_cs_script
+    "
   execute_process(
     COMMAND ${_cs_command}  ${CMAKE_BINARY_DIR}/${pkg_tarname}.tar.gz
     OUTPUT_FILE ${CMAKE_BINARY_DIR}/${pkg_tarname}.sha256
@@ -68,7 +68,8 @@ set(_cs_script "
     ${CMAKE_BINARY_DIR}/${pkg_displayname}.xml
     @ONLY
   )
-")
+"
+)
 file(WRITE "${CMAKE_BINARY_DIR}/checksum.cmake" ${_cs_script})
 
 function (tarball_target)
@@ -79,7 +80,8 @@ function (tarball_target)
     COMMAND cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/app/files
             -DBUILD_TYPE:STRING=tarball ${CMAKE_BINARY_DIR}
   )
-  set(_tarball_script "
+  set(_tarball_script
+      "
     execute_process(COMMAND ${_build_cmd})
     execute_process(COMMAND ${_install_cmd})
     execute_process(
@@ -96,11 +98,12 @@ function (tarball_target)
 
     execute_process( COMMAND cmake -P ${CMAKE_BINARY_DIR}/checksum.cmake)
     message(STATUS \"Computing checksum in ${pkg_displayname}.xml\")
-  ")
+  "
+  )
   file(WRITE "${CMAKE_BINARY_DIR}/build_tarball.cmake" "${_tarball_script}")
   add_custom_target(tarball)
   add_custom_command(
-    TARGET tarball      # Compute checksum
+    TARGET tarball # Compute checksum
     COMMAND cmake -P ${CMAKE_BINARY_DIR}/build_tarball.cmake
     VERBATIM
   )
@@ -111,12 +114,12 @@ function (flatpak_target manifest)
 
   add_custom_target(flatpak-conf)
   add_custom_command(
-    TARGET flatpak-conf
-    COMMAND
-      cmake -DBUILD_TYPE:STRING=flatpak -Uplugin_target ${CMAKE_BINARY_DIR}
+    TARGET flatpak-conf COMMAND cmake -DBUILD_TYPE:STRING=flatpak
+                                -Uplugin_target ${CMAKE_BINARY_DIR}
   )
   add_custom_target(flatpak-build)
-  set(_fp_script "
+  set(_fp_script
+      "
     execute_process(
       COMMAND
         flatpak-builder --force-clean ${CMAKE_CURRENT_BINARY_DIR}/app
@@ -141,11 +144,12 @@ function (flatpak_target manifest)
       COMMAND cmake -P ${CMAKE_BINARY_DIR}/checksum.cmake
     )
     message(STATUS \"Computing checksum in ${pkg_displayname}.xml\")
-  ")
+  "
+  )
   file(WRITE "${CMAKE_BINARY_DIR}/build_flatpak.cmake" "${_fp_script}")
   add_custom_target(flatpak)
   add_custom_command(
-    TARGET flatpak      # Compute checksum
+    TARGET flatpak # Compute checksum
     COMMAND cmake -P ${CMAKE_BINARY_DIR}/build_flatpak.cmake
     VERBATIM
   )
@@ -158,8 +162,7 @@ function (pkg_target)
   #
   add_custom_target(pkg-conf)
   add_custom_command(
-    TARGET pkg-conf
-    COMMAND cmake -DBUILD_TYPE:STRING=pkg ${CMAKE_BINARY_DIR}
+    TARGET pkg-conf COMMAND cmake -DBUILD_TYPE:STRING=pkg ${CMAKE_BINARY_DIR}
   )
   add_custom_target(pkg-build)
   add_custom_command(TARGET pkg-build COMMAND ${_build_cmd})
@@ -185,30 +188,28 @@ function (help_target)
   add_custom_command(
     TARGET make-warning
     COMMAND cmake -E echo
-      "ERROR: plain make is not supported. Supported targets:"
+            "ERROR: plain make is not supported. Supported targets:"
     COMMAND cmake -E echo
-      "   - tarball: Plugin installer tarball for regular builds."
+            "   - tarball: Plugin installer tarball for regular builds."
     COMMAND cmake -E echo
-      "   - flatpak: Plugin installer tarball for flatpak builds."
+            "   - flatpak: Plugin installer tarball for flatpak builds."
     COMMAND cmake -E echo
-      "   - pkg: Legacy installer package on Windows, Mac and Debian."
+            "   - pkg: Legacy installer package on Windows, Mac and Debian."
     COMMAND cmake -E echo ""
-    COMMAND dont-use-plain-make   # will fail
+    COMMAND dont-use-plain-make # will fail
   )
 
-  if ("${BUILD_TYPE}" STREQUAL "" )
+  if ("${BUILD_TYPE}" STREQUAL "")
     add_dependencies(${PACKAGE_NAME} make-warning)
   endif ()
 endfunction ()
 
 function (create_targets manifest)
-  # Add the primary build targets pkg, flatpak and tarball together
-  # with helper targets. Parameters:
-  # - manifest: Flatpak build manifest
+  # Add the primary build targets pkg, flatpak and tarball together with helper
+  # targets. Parameters: - manifest: Flatpak build manifest
 
   tarball_target()
   flatpak_target(${manifest})
   pkg_target()
   help_target()
 endfunction ()
-


### PR DESCRIPTION
Using this, and the cmake-format utility cmake files can be automatically formatted to the style we use. 