### PR TITLE
ci: flatpak: Don't hardcode the manifest filename.

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -10,8 +10,12 @@
 # a full-fledged VM to run it.
 #
 
-set -xe
-MANIFEST=org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+set -e
+
+MANIFEST=$(find flatpak -name org.opencpn.OpenCPN.Plugin\*yaml)
+MANIFEST=${MANIFEST/flatpak\//}
+echo "Using manifest file: $MANIFEST"
+set -x
 
 # Give the apt update daemons a chance to leave the scene.
 sudo systemctl stop apt-daily.service apt-daily.timer

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -11,9 +11,10 @@
 #
 
 set -e
+pwd
+ls 
 
-MANIFEST=$(find flatpak -name org.opencpn.OpenCPN.Plugin\*yaml)
-MANIFEST=${MANIFEST/flatpak\//}
+MANIFEST=$(cd flatpak; ls org.opencpn.OpenCPN.Plugin*yaml)
 echo "Using manifest file: $MANIFEST"
 set -x
 


### PR DESCRIPTION
Use a wildcard instead. Should make the file generic.