### PR TITLE
Windows: fix the targets rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ and a .dmg image for MacOS:
 #### Building on windows (MSVC)
 On windows, a somewhat different workflow is used:
 
-    > cmake -T v141_xp ..
-    > cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+    > cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
     > cmake --build . --target tarball --config RelWithDebInfo
 
 This is to build the installer tarball. Use _--target pkg_ to build the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,8 +54,7 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmake -T v141_xp ..
-  - cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+  - cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
   - cmd: upload.bat
   - py ..\ci\git-push


### PR DESCRIPTION
Next attempt to clean up the mess in cmakeTargets.cmake w r t how targets are defined. Drops some lines, and make IMHO the code much more clear.

And yes, this time it builds in Windows. Please note that the description for #107 is somewhat misleading, it's obvious from the build log that it fails in an early stage (and that silly, silly cmake just continues despite errors...). Anyway, this should be fixed in this PR.

While on it, simplify the windows build recipe.

