### PR TITLE
build: Local build support, docs and windows batch file (#98).

### DIFF
--- a/BUILD_DEPENDENCIES.md
+++ b/BUILD_DEPENDENCIES.md
@@ -1,0 +1,36 @@
+# Build Dependencies HOWTO
+
+Before making a local build, build dependencies needs to be installed. 
+This document tries to describe the procedures.
+
+## Windows
+Before build, run the `buildwin\win_deps.bat` file. The file requires a
+working choco installation, see https://docs.chocolatey.org/en-us/choco/setup.
+
+The first run will install various software using choco, and should be 
+invoked with administrative privileges. 
+
+Subsequent builds should still invoke the file, but it can be done with
+regular permissions.
+
+## Debian/Ubuntu
+Install build dependencies using something like:
+
+     $ sudo apt install devscripts equivs
+     $ sudo mk-build-deps -ir ci/control
+     $ sudo apt-get -q --allow-unauthenticated install -f
+
+## Flatpak
+Install runtime and opencpn as described in flatpak/README.md
+
+
+## MacOS
+
+Use the ci script, which just builds the artifacts used like
+
+    $ cd build
+    $ ../ci/circleci-build-macos local_build
+
+After the initial run the build dependencies are in place and configured,
+builds could be done using `make tarball` etc. Note that MacOS also
+supports `make create-pkg` which creates a .pkg installer.

--- a/BUILD_DEPENDENCIES.md
+++ b/BUILD_DEPENDENCIES.md
@@ -23,14 +23,11 @@ Install build dependencies using something like:
 ## Flatpak
 Install runtime and opencpn as described in flatpak/README.md
 
-
 ## MacOS
+Use the ci script, which just installs the build deps and configures
+when used in a non-CI environment:
 
-Use the ci script, which just builds the artifacts used like
+    $ ci/circleci-build-macos
 
-    $ cd build
-    $ ../ci/circleci-build-macos local_build
-
-After the initial run the build dependencies are in place and configured,
-builds could be done using `make tarball` etc. Note that MacOS also
-supports `make create-pkg` which creates a .pkg installer.
+After the initial run the build dependencies are in place and configured.
+Make for example the tarball using `cd build; make tarball`

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -6,28 +6,28 @@ rem Initial run will do choco installs requiring administrative
 rem privileges.
 rem
 
-set WXWIN=C:\wxWidgets-3.1.2
-set wxWidgets_ROOT_DIR=%WXWIN%
-set wxWidgets_LIB_DIR=%WXWIN\lib\vc_dll%
 
 SET PATH=C:\Program Files\CMake\bin;C:\Python38;C:\Python38\Scripts;%PATH%
-SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
-
 python --version > nul 2>&1 || choco install -y python
 python --version
-
-if not exist %WXWIN% (
-  wget --version > nul 2>&1 || choco install -y wget
-  wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -O wxWidgets-3.1.2.7z
-  7z i > nul 2>&1 || choco install -y 7z
-  7z x wxWidgets-3.1.2.7z -o%WXWIN%
-)
 python -m ensurepip
 python -m pip install --upgrade pip
 python -m pip install -q setuptools wheel
 python -m pip install -q cloudsmith-cli
 python -m pip install -q cryptography
 
-if not exist "C:\Program Files (x86)\Poedit" (
-  choco install-y  poedit
+set WXWIN=C:\wxWidgets-3.1.2
+set wxWidgets_ROOT_DIR=%WXWIN%
+set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
+SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%
+if not exist %WXWIN% (
+  wget --version > nul 2>&1 || choco install -y wget
+  wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -O wxWidgets-3.1.2.7z
+  7z i > nul 2>&1 || choco install -y 7z
+  7z x wxWidgets-3.1.2.7z -o%WXWIN%
 )
+
+if not exist "C:\Program Files (x86)\Poedit" (
+  choco install -y  poedit
+)
+SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -1,0 +1,33 @@
+rem
+rem Install build dependencies. Requires a working choco installation,
+rem see https://docs.chocolatey.org/en-us/choco/setup. 
+rem
+rem Initial run will do choco installs requiring administrative 
+rem privileges.
+rem
+
+set WXWIN=C:\wxWidgets-3.1.2
+set wxWidgets_ROOT_DIR=%WXWIN%
+set wxWidgets_LIB_DIR=%WXWIN\lib\vc_dll%
+
+SET PATH=C:\Program Files\CMake\bin;C:\Python38;C:\Python38\Scripts;%PATH%
+SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
+
+python --version > nul 2>&1 || choco install -y python
+python --version
+
+if not exist %WXWIN% (
+  wget --version > nul 2>&1 || choco install -y wget
+  wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -O wxWidgets-3.1.2.7z
+  7z i > nul 2>&1 || choco install -y 7z
+  7z x wxWidgets-3.1.2.7z -o%WXWIN%
+)
+python -m ensurepip
+python -m pip install --upgrade pip
+python -m pip install -q setuptools wheel
+python -m pip install -q cloudsmith-cli
+python -m pip install -q cryptography
+
+if not exist "C:\Program Files (x86)\Poedit" (
+  choco install-y  poedit
+)

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -46,7 +46,11 @@ cmake \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 
-if [ "$1" = 'local_build' ]; then exit 0; fi
+if [ -z "$CLOUDSMITH_API_KEY" ]; then
+    echo 'No $CLOUDSMITH_API_KEY found, assuming local setup'
+    echo "Complete build using 'cd build; make tarball' or so."
+    exit 0 
+fi
 
 make -j $(sysctl -n hw.physicalcpu) VERBOSE=1 tarball
 

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -45,6 +45,9 @@ cmake \
   -DCMAKE_INSTALL_PREFIX= \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
+
+if [ "$1" = 'local_build' ]; then exit 0; fi
+
 make -j $(sysctl -n hw.physicalcpu) VERBOSE=1 tarball
 
 make create-pkg

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -67,6 +67,13 @@ set(_cs_script "
 )")
 file(WRITE "${CMAKE_BINARY_DIR}/checksum.cmake" ${_cs_script})
 
+# Command to build legacy package
+if (APPLE)
+    set(_build_pkg_cmd ${_build_target_cmd} create-pkg)
+else ()
+    set(_build_pkg_cmd ${_build_target_cmd} package)
+endif ()
+
 
 function (tarball_target)
 
@@ -178,7 +185,7 @@ function (pkg_target)
   add_custom_command(
     TARGET pkg-package
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND cpack $<$<BOOL:$<CONFIG>>:"-C $<CONFIG>">
+    COMMAND ${_build_pkg_cmd}
   )
   add_dependencies(pkg-build pkg-conf)
   add_dependencies(pkg-package pkg-build)


### PR DESCRIPTION
Please modify this PR. My idea is that the BUILD_DEPENDENCIES.md info  should live in the wiki, it's hard to maintain multiple copies in different plugins. OTOH, submitting a file in a PR is the best way I know to forward in to you. So please remove this file, possibly after including useful parts in the wiki.

The windows batch file and the macos ci fix is ok though, I think. The macos patch is extremely dirty, we might need to have a fresh look at it.