### PR TITLE
Opengl  update for cmake/PluginLibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,13 @@ cmake_minimum_required(VERSION 3.5.1)
 
 cmake_policy(SET CMP0042 NEW)
 
+if (POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+endif ()
+
 if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif ()
-
-# Prefer libGL.so to libOpenGL.so, see CMP0072
-set(OpenGL_GL_PREFERENCE "LEGACY")
 
 # Locations where cmake looks for cmake modules.
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/build ${CMAKE_SOURCE_DIR}/cmake)

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -24,6 +24,6 @@ sudo apt-get install \
     python3-pip python3-setuptools python3-dev python3-wheel \
     build-essential libssl-dev libffi-dev 
 
-python3 -m pip install --user --upgrade pip
-python3 -m pip install --user -q cloudsmith-cli
-python3 -m pip install --user -q cryptography
+# Latest pip 21.0.0 is broken:
+python3 -m pip install --force-reinstall pip==20.3.4
+python3 -m pip install --user -q cloudsmith-cli cryptography 

--- a/ci/generic-build-raspbian-armhf.sh
+++ b/ci/generic-build-raspbian-armhf.sh
@@ -56,7 +56,8 @@ rm -f build.sh
 # Install cloudsmith-cli,  required by upload.sh.
 pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
     > $HOME/.python-version
-python3 -m pip install --upgrade pip
+# Latest pip 21.0.0 is broken:
+python3 -m pip install --force-reinstall pip==20.3.4
 python3 -m pip install --user cloudsmith-cli
 python3 -m pip install --user cryptography
 

--- a/cmake/PluginCompiler.cmake
+++ b/cmake/PluginCompiler.cmake
@@ -13,7 +13,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   string(APPEND CMAKE_C_FLAGS " ${_ocpn_cflags}")
   string(APPEND CMAKE_CXX_FLAGS " ${_ocpn_cflags}")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")              # Apple is AppleClang
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")           # Apple is AppleClang
   string(APPEND CMAKE_C_FLAGS " ${_ocpn_cflags}")
   string(APPEND CMAKE_CXX_FLAGS " ${_ocpn_cflags}")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl -undefined dynamic_lookup")
@@ -22,5 +22,14 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif ()
 
 if (UNIX AND NOT APPLE)   # linux, see OpenCPN/OpenCPN#1977
-  set_target_properties(${PACKAGE_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN:$ORIGIN/..")
+  set_target_properties(${PACKAGE_NAME}
+    PROPERTIES INSTALL_RPATH "$ORIGIN:$ORIGIN/.."
+  )
 endif ()
+
+if (MINGW)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L../buildwin")
+endif ()
+
+
+

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -47,11 +47,6 @@ if (NOT QT_ANDROID)
   include(${wxWidgets_USE_FILE})	
 endif ()
 
-if (MINGW)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L../buildwin")
-endif ()
-
-
 # On Android, PlugIns need a specific linkage set....
 if (QT_ANDROID)
   # These libraries are needed to create PlugIns on Android.

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -35,7 +35,6 @@ if (NOT QT_ANDROID)
   endif ()
 
   set(wxWidgets_USE_LIBS base core net xml html adv stc)
-  set(BUILD_SHARED_LIBS TRUE)
 
   find_package(wxWidgets REQUIRED base core net xml html adv stc)
   if (MSYS)

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -38,14 +38,14 @@ if (NOT QT_ANDROID)
   set(BUILD_SHARED_LIBS TRUE)
 
   find_package(wxWidgets REQUIRED base core net xml html adv stc)
-
-  if(MSYS)
-  # this is just a hack. I think the bug is in FindwxWidgets.cmake
-    string( REGEX REPLACE "/usr/local" "\\\\;C:/MinGW/msys/1.0/usr/local" wxWidgets_INCLUDE_DIRS ${wxWidgets_INCLUDE_DIRS} )
-  endif()
-
+  if (MSYS)
+    # This is just a hack. I think the bug is in FindwxWidgets.cmake
+    string(
+      REGEX REPLACE "/usr/local" "\\\\;C:/MinGW/msys/1.0/usr/local"
+      wxWidgets_INCLUDE_DIRS ${wxWidgets_INCLUDE_DIRS}
+    )
+  endif ()
   include(${wxWidgets_USE_FILE})	
-	
 endif ()
 
 if (MINGW)


### PR DESCRIPTION
PluginLibs contains more copy-pasted copy which just doesn't make sense: It locates the IOpenGL libraries, but does not link to them. Fix this, let PluginLibs both locate and link to OpenGL.

While on it: various cleanup and a fix for latest python pip 21.0.0 which is broken, crashes directly on invocation.