### PR TITLE
build: macos: Don't hardcode library paths (#125).

### DIFF
--- a/cmake/fix-macos-libs.sh
+++ b/cmake/fix-macos-libs.sh
@@ -4,7 +4,7 @@
 # location ot the target MacOS system where they are installed
 # as part of OpenCPN
 
-readonly RUNTIME_PATH="/Applications/OpenCPN.app/Contents/Frameworks"
+readonly RUNTIME_PATH="@executable_path/../Frameworks/"
 
 plugin=$(find app/files -name '*.dylib')
 


### PR DESCRIPTION
As heading says: Use relative library  paths instead of absolute. This will make the paths sane even if OpenCPN is installed in a non-default location.

Closes: #125

EDIT: Circle ci bulid logs [here](https://app.circleci.com/pipelines/github/leamas/shipdriver_pi/736/workflows/eb2a53fe-8344-4ace-b582-5aa3c65e9a72)