### PR TITLE
List deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ debian-steps: &debian-steps
   steps:
     - checkout
     - run: ci/circleci-build-debian.sh
+    - run: sh -c "ldd  build/app/*/lib/opencpn/*.so"
     - run: cd build; /bin/bash < upload.sh
     - run: python3 ci/git-push
 
@@ -57,6 +58,7 @@ jobs:
             - /usr/local/Cellar
             - /usr/local/lib
             - /usr/local/include
+      - run: sh -c "otool -L build/app/*/OpenCPN.app/Contents/PlugIns/*.dylib"
       - run: cd build; /bin/bash < upload.sh
       - run: python3 ci/git-push
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ build_script:
   - cd build
   - cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
+  - py ..\ci\windows-ldd
   - cmd: upload.bat
   - py ..\ci\git-push
 

--- a/ci/generic-build-raspbian-armhf.sh
+++ b/ci/generic-build-raspbian-armhf.sh
@@ -48,6 +48,7 @@ cd /ci-source
 rm -rf build; mkdir build; cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 tarball
+ldd  app/*/lib/opencpn/*.so
 EOF
 
 docker exec -ti \

--- a/ci/windows-ldd
+++ b/ci/windows-ldd
@@ -3,12 +3,10 @@
 # the plugin dll.
 
 import subprocess
-import sys
 import glob
 dumpbin = glob.glob(
   "C:/Program Files (x86)/*Visual Studio/2017/Community/VC/Tools/MSVC/*/bin/Hostx64/x64")[0]
 dumpbin += "/dumpbin"
-subprocess.run(["dir", "C:/project/opencpn/photolayer_pi/build/app"])
 lib = glob.glob("C:/project/opencpn/*/build/app/*/plugins/*.dll")[0]
 subprocess.run([dumpbin, "/dependents", lib])
 

--- a/ci/windows-ldd
+++ b/ci/windows-ldd
@@ -1,0 +1,14 @@
+#
+# Python script running the Visual Studio dumpbin tool on
+# the plugin dll.
+
+import subprocess
+import sys
+import glob
+dumpbin = glob.glob(
+  "C:/Program Files (x86)/*Visual Studio/2017/Community/VC/Tools/MSVC/*/bin/Hostx64/x64")[0]
+dumpbin += "/dumpbin"
+subprocess.run(["dir", "C:/project/opencpn/photolayer_pi/build/app"])
+lib = glob.glob("C:/project/opencpn/*/build/app/*/plugins/*.dll")[0]
+subprocess.run([dumpbin, "/dependents", lib])
+


### PR DESCRIPTION
Add a final step to the ci builds which lists the runtime dependencies of the plugin shared library, for QA and debugging purposes.

Partly backported from photolayer