### PR TITLE
ci: circleci: Build all branches besides tmp and tmp-*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,9 @@ jobs:
 std-filters: &std-filters
   filters:
     branches:
-      only:
-        - master
-        - build
+      ignore:
+        - tmp
+        - /tmp-.*/
 
 workflows:
   version: 2


### PR DESCRIPTION
As heading says: make circleci builds opt-out rather than opt-in w r t branch names.