### PR TITLE
cmake: Targets, PluginInstall: flatpak strip fix (#140).

### DIFF
--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -67,7 +67,8 @@ if (CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
     set(_striplib OpenCPN.app/Contents/PlugIns/lib${PACKAGE_NAME}.dylib)
   elseif (MINGW)
     set(_striplib plugins/lib${PACKAGE_NAME}.dll)
-  elseif (UNIX AND NOT CMAKE_CROSSCOMPILING)  # linux
+  elseif (UNIX AND NOT CMAKE_CROSSCOMPILING AND NOT DEFINED ENV{FLATPAK_ID})
+    # Plain, native linux
     set(_striplib lib/opencpn/lib${PACKAGE_NAME}.so)
   endif ()
   if (BUILD_TYPE STREQUAL "tarball" AND DEFINED _striplib)
@@ -75,14 +76,12 @@ if (CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
     if (APPLE)
       set(STRIP_UTIL "${STRIP_UTIL} -x")
     endif ()
-    install(CODE
-      "execute_process(COMMAND cmake -E echo Stripping ${_striplib})"
-    )
-    install(CODE
-      "execute_process(
+    install(CODE "message(STATUS \"Stripping ${_striplib}\"")
+    install(CODE "
+      execute_process(
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMAND ${STRIP_UTIL} app/files/${_striplib}
-      )"
-    )
+      )
+    ")
   endif ()
 endif ()

--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -76,7 +76,7 @@ if (CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel")
     if (APPLE)
       set(STRIP_UTIL "${STRIP_UTIL} -x")
     endif ()
-    install(CODE "message(STATUS \"Stripping ${_striplib}\"")
+    install(CODE "message(STATUS \"Stripping ${_striplib}\")")
     install(CODE "
       execute_process(
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -133,6 +133,12 @@ function (flatpak_target manifest)
       COMMAND bash -c \"sed -e '/@checksum@/d' \
           < ${pkg_displayname}.xml.in > app/files/metadata.xml\"
     )
+    if (${CMAKE_BUILD_TYPE} MATCHES Release|MinSizeRel)
+      message(STATUS \"Stripping app/files/lib/opencpn/lib${PACKAGE_NAME}.so\")
+      execute_process(
+        COMMAND strip app/files/lib/opencpn/lib${PACKAGE_NAME}.so
+      )
+    endif ()
     execute_process(
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/app
       COMMAND mv -fT files ${pkg_displayname}


### PR DESCRIPTION
As heading says: make sure that Release and MInSizRel builds strips the plugin library file.

Closes: #140