### PR TITLE
ci: Python mess update.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
       - image: circleci/buildpack-deps:xenial-scm
     environment:
       - OCPN_TARGET: xenial
+      - USE_DEADSNAKES_PY37: 1
     <<: *debian-steps
 
   build-bionic:

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -5,11 +5,19 @@
 #
 set -xe
 sudo apt -qq update || apt update
-sudo apt-get -q install  devscripts equivs
+sudo apt-get -qq install devscripts equivs software-properties-common
 
-mkdir  build
-cd build
-sudo mk-build-deps -ir ../build-deps/control
+if [ -n  "$USE_DEADSNAKES_PY37" ]; then
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+    sudo apt -qq update
+    sudo  apt-get -q install  python3.7
+    for py in $(ls /usr/bin/python3.[0-9]); do
+        sudo update-alternatives --install /usr/bin/python3 python3 $py 1
+    done
+    sudo update-alternatives --set python3 /usr/bin/python3.7
+fi
+
+sudo mk-build-deps -ir build-deps/control
 sudo apt-get -q --allow-unauthenticated install -f
 
 if [ -n "$BUILD_GTK3" ]; then
@@ -17,13 +25,14 @@ if [ -n "$BUILD_GTK3" ]; then
         /usr/lib/*-linux-*/wx/config/gtk3-unicode-3.0
 fi
 
-sudo apt-get install \
+sudo apt install -q \
     python3-pip python3-setuptools python3-dev python3-wheel \
     build-essential libssl-dev libffi-dev 
 
-# Latest pip 21.0.0 is broken:
-python3 -m pip install --force-reinstall pip==20.3.4
+python3 -m pip install --user --upgrade -q setuptools wheel pip
 python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 
+mkdir  build
+cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 tarball

--- a/ci/circleci-build-mingw.sh
+++ b/ci/circleci-build-mingw.sh
@@ -51,7 +51,9 @@ pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
     > $HOME/.python-version
 
 # Install cloudsmith(for upload script) and cryptography (for git-push).
-python3 -m pip install --user cloudsmith-cli cryptography
+# https://github.com/pyca/cryptography/issues/5753 -> cryptography < 3.4
+python3 -m pip install --upgrade --user -q pip setuptools
+python3 -m pip install --user -q cloudsmith-cli cryptography
 
 # python installs scripts in ~/.local/bin, teach upload.sh to use it in PATH:
 echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc

--- a/ci/generic-build-raspbian-armhf.sh
+++ b/ci/generic-build-raspbian-armhf.sh
@@ -62,7 +62,8 @@ pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1 \
     > $HOME/.python-version
 # Latest pip 21.0.0 is broken:
 python3 -m pip install --force-reinstall pip==20.3.4
-python3 -m pip install --user cloudsmith-cli cryptography
+# https://github.com/pyca/cryptography/issues/5753 -> cryptography < 3.4
+python3 -m pip install --user cloudsmith-cli 'cryptography<3.4'
 
 # python install scripts in ~/.local/bin, teach upload.sh to use in it's PATH:
 echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc


### PR DESCRIPTION
Basically trying to cope with version requirements from the cryptography
and cloudsmith-cli python modules which are reflected in requirements
on python3-pip and python3-setuptools. It builds, but it is still a
mess.

Circle ci build logs [here](https://app.circleci.com/pipelines/github/leamas/shipdriver_pi/772/workflows/1b6183c9-ead1-45ec-bbd4-34134ffe6ff9)