### PR TITLE
appveyor: Make file generic.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-clone_folder: c:\project\opencpn\shipdriver_pi
+clone_folder: c:\project\opencpn\plugin_src
 shallow_clone: false
 clone_depth: 10
 


### PR DESCRIPTION
Change the one and only line which needs editing when used in
another plugin. With this change, there is one file less to edit
when adapting files to a new plugin.