### PR TITLE
appveyor: Make file generic.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-clone_folder: c:\project\opencpn\shipdriver_pi
+clone_folder: c:\project\opencpn\plugin_src
 shallow_clone: false
 clone_depth: 10
 

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -47,8 +47,8 @@ cmake \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 
-if [ -z "$CLOUDSMITH_API_KEY" ]; then
-    echo 'No $CLOUDSMITH_API_KEY found, assuming local setup'
+if [[ -z "$CI" ]]; then
+    echo '$CI not found in environment, assuming local setup'
     echo "Complete build using 'cd build; make tarball' or so."
     exit 0 
 fi


### PR DESCRIPTION
Change the one and only line which needs editing when used in
another plugin. With this change, there is one file less to edit
when adapting files to a new plugin.