### PR TITLE
shipdriver-plugin.xml.in: Make it generic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ option(SHIPDRIVER_USE_SVG "Use SVG graphics" ON)
 # -------  Plugin setup --------
 #
 project(ShipDriver_pi VERSION 2.6.2.0)
+set(PKG_RELEASE "1")
 
 set(DISPLAY_NAME ShipDriver)    # Dialogs, installer artifacts, ...
 set(PLUGIN_API_NAME ShipDriver) # As of GetCommonName() in plugin API
@@ -71,8 +72,10 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
 ]=])
 
-set(PKG_RELEASE "1")
 set(PKG_AUTHOR "Mike Rossiter")
+set(PKG_IS_OPEN_SOURCE "yes")
+set(CPACK_PACKAGE_HOMEPAGE_URL https://github.com/Rasbats/shipdriver_pi)
+set(PKG_INFO_URL https://opencpn.org/OpenCPN/plugins/shipdriver.html)
 
 set(SRC
     src/ShipDriver_pi.h

--- a/shipdriver-plugin.xml.in
+++ b/shipdriver-plugin.xml.in
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-  <name> ShipDriver </name>
+  <name> @PLUGIN_API_NAME@ </name>
   <version> @pkg_semver@ </version>
   <release> @PKG_RELEASE@ </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <summary> @CPACK_PACKAGE_DESCRIPTION_SUMMARY@ </summary>
 
   <api-version> @API_VERSION@ </api-version>
-  <open-source> yes </open-source>
+  <open-source> @PKG_IS_OPEN_SOURCE@ </open-source>
   <author> @PKG_AUTHOR@ </author>
-  <source> https://github.com/Rasbats/shipdriver_pi </source>
-  <info-url> https://opencpn.org/OpenCPN/plugins/shipdriver.html </info-url>
+  <source> @CPACK_PACKAGE_HOMEPAGE_URL@ </source>
+  <info-url> @PKG_INFO_URL@ </info-url>
 
   <description> @CPACK_PACKAGE_DESCRIPTION@ </description>
 


### PR DESCRIPTION
To the price of just a few extra lines in CMakeLists.txt the .xml.in
file can be made fully generic. Less documentation and error-prone
manual steps make this change pay off despite some otherwise
needless lines in CMakeLists.txt