### PR TITLE
cmake: Define number of processor in configure time.

### DIFF
--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -35,4 +35,4 @@ python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 mkdir  build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j $(nproc) VERBOSE=1 tarball
+make VERBOSE=1 tarball

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -53,7 +53,7 @@ if [[ -z "$CI" ]]; then
     exit 0 
 fi
 
-make -j $(sysctl -n hw.physicalcpu) VERBOSE=1 tarball
+make VERBOSE=1 tarball
 
 make create-pkg
 

--- a/cmake/PluginCompiler.cmake
+++ b/cmake/PluginCompiler.cmake
@@ -6,7 +6,39 @@
 # Set up the compilation environment, compiler options etc.
 # ~~~
 
-message(STATUS "*** Staging to build ${PACKAGE_NAME} ***")
+
+# Set up option NPROC: Number of processors used when compiling.
+if (DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+  set(_nproc $ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+else ()
+  if (WIN32)
+    set(_nproc_cmd
+      cmd /C if defined NUMBER_OF_PROCESSORS (echo %NUMBER_OF_PROCESSORS%)
+      else (echo 1)
+    )
+
+  elseif (APPLE)
+    set(_nproc_cmd sysctl -n hw.physicalcpu)
+  else ()
+    set(_nproc_cmd nproc)
+  endif ()
+  execute_process(
+    COMMAND ${_nproc_cmd}
+    OUTPUT_VARIABLE _nproc
+    RESULT_VARIABLE _status
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (NOT "${_status}" STREQUAL "0")
+    set(_nproc 1)
+    message(
+      STATUS "Cannot probe for processor count using \"${_nproc_cmd}\""
+    )
+  endif ()
+endif ()
+set(OCPN_NPROC ${_nproc}
+  CACHE STRING "Number of processors used to compile [${_nproc}]"
+)
+message(STATUS "Build uses ${OCPN_NPROC} processors")
 
 set(_ocpn_cflags " -Wall -Wno-unused-result -fexceptions")
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -30,6 +62,3 @@ endif ()
 if (MINGW)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L../buildwin")
 endif ()
-
-
-

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -8,6 +8,7 @@ if (TARGET tarball-build)
 endif ()
 
 include(Metadata)
+include(PluginCompiler)
 
 if (WIN32)
   if (${CMAKE_MAJOR_VERSION} LESS 3 OR ${CMAKE_MINOR_VERSION} LESS 16)
@@ -17,7 +18,7 @@ endif ()
 
 # Set up _build_cmd
 set(_build_cmd
-  cmake --build ${CMAKE_BINARY_DIR} --parallel --config $<CONFIG>
+  cmake --build ${CMAKE_BINARY_DIR} --parallel ${OCPN_NPROC} --config $<CONFIG>
 )
 
 # Set up _build_target_cmd and _install_cmd


### PR DESCRIPTION
The simple "make tarball" breaks on platforms where the default number
of processors fills the available memory. Reported on arm builds.

The CI builds has walked around this by setting the processor count
using make -j $count. This works, but is not that user-friendly.

Define a new NPROC option used to define processor count with
hopefully sane default values, including respecting the
documented CMAKE_BUILD_PARALLEL_LEVEL

Fix is already applied and tested in radar_pi.