### PR TITLE
PluginLibs: Windows: Warn if win_deps.bat has not been run.

### DIFF
--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -34,6 +34,16 @@ endif ()
 set(wxWidgets_USE_LIBS base core net xml html adv stc)
 set(BUILD_SHARED_LIBS TRUE)
 
+set(_bad_win_env_msg [=[
+%WXWIN% is not present in environment, win_deps.bat has not been run.
+Build might work, but most likely fail when not finding wxWidgets.
+Run buildwin\win_deps.bat or set %WXWIN% to mute this message.
+]=])
+
+if (WIN32 AND NOT DEFINED ENV{WXWIN})
+  message(WARNING ${_bad_win_env_msg})
+endif ()
+
 find_package(wxWidgets REQUIRED base core net xml html adv stc)
 if (MSYS)
   # This is just a hack. I think the bug is in FindwxWidgets.cmake


### PR DESCRIPTION
As discussed in zulip: Warn if windows user hasn't run win_deps.bat