### PR TITLE
Don't label armhf packages as A64 (#169).

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -82,7 +82,7 @@ endif ()
 set(pkg_semver "${PROJECT_VERSION}${_pre_rel}+${_build_id}.${_gitversion}")
 
 # pkg_displayname: Used for xml metadata and GUI name
-if (ARCH MATCHES "arm|aarch64")
+if (ARCH MATCHES "arm64|aarch64")
   set(_display_arch "-A64")
 endif()
 string(CONCAT pkg_displayname


### PR DESCRIPTION
Closes: #169