### PR TITLE
ci: Update flatpak builds (#175).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,22 @@ debian-steps: &debian-steps
     - run: cd build; /bin/bash < upload.sh
     - run: python3 ci/git-push
 
+flatpak-steps: &flatpak-steps
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
+    - run: ci/circleci-build-flatpak.sh
+    - save_cache:
+        key: <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
+        paths:
+          - /home/circleci/.local/share/flatpak/repo
+    - run: cd build; /bin/bash < upload.sh
+    - run: python3 ci/git-push
+
 jobs:
+
   build-flatpak-arm64:
     machine:
       image: ubuntu-2004:202101-01
@@ -17,39 +32,36 @@ jobs:
     environment:
       - OCPN_TARGET: flatpak-arm64
       - FLATPAK_BRANCH: beta
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - fp-a64-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
-      - run: ci/circleci-build-flatpak.sh
-      - save_cache:
-          key: fp-a64-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
-          paths:
-            - /home/circleci/.local/share/flatpak/repo
-      - run: cd build; /bin/bash < upload.sh
-      - run: python3 ci/git-push
+    parameters:
+      cache-key:
+        type: string
+        default: "fp-arm20-v1"
+    <<: *flatpak-steps
 
-  build-flatpak:
+  build-flatpak-x86-1808:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
-      - USE_CUSTOM_PPA: yes
       - FLATPAK_BRANCH: stable
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
-      - run: ci/circleci-build-flatpak.sh
-      - save_cache:
-          key: fp-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
-          paths:
-            - /home/circleci/.local/share/flatpak/repo
-      - run: cd build; /bin/bash < upload.sh
-      - run: python3 ci/git-push
+    parameters:
+      cache-key:
+        type: string
+        default: "fp-x86-18-v1"
+    <<: *flatpak-steps
 
+  build-flatpak-x86-2008:
+    machine:
+      image: ubuntu-2004:202010-01
+    environment:
+      - OCPN_TARGET: flatpak
+      - FLATPAK_BRANCH: beta
+    parameters:
+      cache-key:
+        type: string
+        default: "fp-x86-20-v1"
+    <<: *flatpak-steps
+ 
   build-macos:
     macos:
       xcode: "11.0.0"
@@ -121,12 +133,16 @@ workflows:
   version: 2
   build_all:
     jobs:
+
       - build-flatpak-arm64:
           <<: *std-filters
 
-      - build-flatpak:
+      - build-flatpak-x86-1808:
           <<: *std-filters
 
+      - build-flatpak-x86-2008:
+          <<: *std-filters
+ 
       - build-macos:
           <<: *std-filters
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -9,29 +9,13 @@ MANIFEST=$(cd flatpak; ls org.opencpn.OpenCPN.Plugin*yaml)
 echo "Using manifest file: $MANIFEST"
 set -x
 
-# On old systems: give the apt update daemons a chance to leave the scene
-# while we build.
-if systemctl status apt-daily-upgrade.service &> /dev/null; then
-    sudo systemctl stop apt-daily.service apt-daily.timer
-    sudo systemctl kill --kill-who=all \
-        apt-daily.service apt-daily-upgrade.service
-    sudo systemctl mask apt-daily.service apt-daily-upgrade.service
-    sudo systemctl daemon-reload
-fi
-
-# Install the flatpak PPA so we can access a usable flatpak version
-# (not available on Ubuntu Xenial 16.04)
-if [ -n "$USE_CUSTOM_PPA" ]; then
-    sudo add-apt-repository -y ppa:alexlarsson/flatpak
-    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
-        | sudo apt-key add -
-fi
 sudo apt update
 
+
+# Install flatpak and flatpak-builder
 sudo apt install flatpak flatpak-builder
 flatpak remote-add --user --if-not-exists \
     flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-
 
 # For now, horrible hack: aarch 64 builds are using the updated runtime
 # 20.08 and the opencpn beta version using old 18.08 runtime.
@@ -59,10 +43,6 @@ sed -i "/^runtime-version/s/:.*/: $FLATPAK_BRANCH/" flatpak/$MANIFEST
 pyenv local $(pyenv versions | sed 's/*//' | awk '{print $1}' | tail -1)
 cp .python-version $HOME
 
-# Install a recent cmake, ubuntu 16.04 is too old.
-export PATH=$HOME/.local/bin:$PATH
-python -m pip install --user cmake
-
 # Configure and build the plugin tarball and metadata.
 mkdir build; cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
@@ -71,17 +51,9 @@ make -j $(nproc) VERBOSE=1 flatpak
 # Restore patched file so the cache checksumming is ok.
 git checkout ../flatpak/$MANIFEST
 
-# Wait for apt-daily to complete. apt-daily should not restart, it's masked.
-# https://unix.stackexchange.com/questions/315502
-echo -n "Waiting for apt_daily lock..."
-sudo flock /var/lib/apt/daily_lock echo done
-
-# Install cloudsmith, required by upload script
-python3 -m pip install --user --upgrade pip
-python3 -m pip install --user cloudsmith-cli
-
-# Required by git-push
-python3 -m pip install --user cryptography
+# Install cloudsmith and cryptography, required by upload script and git-push
+python3 -m pip install -q --user --upgrade pip
+python3 -m pip install -q --user cloudsmith-cli cryptography
 
 # python install scripts in ~/.local/bin, teach upload.sh to use this in PATH
 echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc


### PR DESCRIPTION
Build the three flatpak variants for 5.6.0: aarch64/20.08, x86_64/18.08 and x86_64/20.08.

This is ported from upcoming o-charts_pi, the successor of oesenc_pi. The build routines have been tested and should be reasonably stable.

Closes: #175