### PR TITLE
Ci flatpak 187 v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,10 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: flatpak-arm64
-      - FLATPAK_BRANCH: beta
     parameters:
       cache-key:
         type: string
-        default: "fp-arm20-v1"
+        default: "fp-arm20-v2"
     <<: *flatpak-steps
 
   build-flatpak-x86-1808:
@@ -43,11 +42,11 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
-      - FLATPAK_BRANCH: stable
+      - BUILD_1808: "true"
     parameters:
       cache-key:
         type: string
-        default: "fp-x86-18-v1"
+        default: "fp-x86-18-v2"
     <<: *flatpak-steps
 
   build-flatpak-x86-2008:
@@ -55,11 +54,10 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
-      - FLATPAK_BRANCH: beta
     parameters:
       cache-key:
         type: string
-        default: "fp-x86-20-v1"
+        default: "fp-x86-20-v2"
     <<: *flatpak-steps
  
   build-macos:

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -31,7 +31,7 @@ if dpkg-architecture --is arm64; then
     flatpak install --user -y --or-update  --noninteractive \
         flathub-beta org.opencpn.OpenCPN
     FLATPAK_BRANCH=beta
-elif [ -n "BUILD_1808" ]; then
+elif [ -n "$BUILD_1808" ]; then
     flatpak install --user -y --noninteractive \
         flathub org.freedesktop.Sdk//18.08
     flatpak install --user -y --or-update --noninteractive \

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -60,7 +60,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 flatpak
 
 # Fix upload script if building 18.08:
-test -n "$BUILD_1808" && sed -i 's/20.08/18.08/' build/upload.sh
+test -n "$BUILD_1808" && sed -i 's/20.08/18.08/' upload.sh
 
 # Restore patched file so the cache checksumming is ok.
 git checkout ../flatpak/$MANIFEST


### PR DESCRIPTION
Hopefully, the last bugfix. First id didn't build 18.08, then it always built 18.08. This time, 18.08 should be built as it should. 

Sigh