### PR TITLE
Filenames and such

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,6 @@ steps:
       GIT_KEY_PASSWORD:
         from_secret: GIT_KEY_PASSWORD
     commands:
-      - echo ${CLOUDSMITH_BETA_REPO}
       - export PATH=$HOME/.local/bin:$PATH
       - /bin/bash ci/drone-build-raspbian.sh
       - bash -c "cd build; bash < upload.sh"
@@ -64,6 +63,3 @@ steps:
       - ci/drone-build-raspbian.sh
       - bash -c "cd build; bash < upload.sh"
       - python3 ci/git-push
-trigger:
-  event:
-  - tag

--- a/ci/upload.bat.in
+++ b/ci/upload.bat.in
@@ -17,10 +17,12 @@ cloudsmith push raw --no-wait-for-sync ^
     --name @pkg_displayname@-metadata ^
     --version @pkg_semver@ ^
     --summary "Plugin metadata for automatic installation" ^
+    --republish ^
     @pkg_repo@ @pkg_xmlname@.xml
 
 cloudsmith push raw --no-wait-for-sync ^
     --name @pkg_displayname@-tarball ^
     --version @pkg_semver@ ^
     --summary "Plugin tarball for automatic installation" ^
+    --republish ^
     @pkg_repo@ @pkg_tarname@.tar.gz

--- a/ci/upload.sh.in
+++ b/ci/upload.sh.in
@@ -21,10 +21,12 @@ cloudsmith push raw --no-wait-for-sync \
     --name @pkg_displayname@-metadata \
     --version @pkg_semver@ \
     --summary "Plugin metadata for automatic installation" \
+    --republish \
     @pkg_repo@ @pkg_xmlname@.xml
 
 cloudsmith push raw --no-wait-for-sync \
     --name @pkg_displayname@-tarball \
     --version @pkg_semver@ \
     --summary "Plugin tarball for automatic installation" \
+    --republish \
     @pkg_repo@ @pkg_tarname@.tar.gz

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -95,13 +95,14 @@ string(REGEX REPLACE "([a-zA-Z0-9/-])" "\\1 " pkg_repo_display  ${pkg_repo})
 message(STATUS "Selected upload repository: ${pkg_repo_display}")
 
 # pkg_semver: Complete version including pre-release tag and build info
+# for untagged builds.
 set(_pre_rel ${PKG_PRERELEASE})
-if (_pre_rel MATCHES "^[^-]")
+if (NOT "${_pre_rel}" STREQUAL "" AND _pre_rel MATCHES "^[^-]")
   string(PREPEND _pre_rel "-")
 endif ()
 set(pkg_semver "${PROJECT_VERSION}${_pre_rel}+${_build_id}.${_gitversion}")
 
-# pkg_displayname: Used for xml metadata and GUI name
+# pkg_displayname: GUI name
 if (ARCH MATCHES "arm64|aarch64")
   set(_display_arch "-A64")
 endif()
@@ -109,8 +110,9 @@ string(CONCAT pkg_displayname
   "${PLUGIN_API_NAME}-${VERSION_MAJOR}.${VERSION_MINOR}"
   "-${plugin_target}${_display_arch}-${plugin_target_version}"
 )
+
 # pkg_xmlname: XML metadata basename
-set(pkg_xmlname ${pkg_displayname}-${_build_id})
+set(pkg_xmlname ${pkg_displayname})
 
 # pkg_tarname: Tarball basename
 if (NOT "${_git_tag}" STREQUAL "")

--- a/plugin.xml.in
+++ b/plugin.xml.in
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- @pkg_build_info@ -->
 <plugin version="1">
   <name> @PLUGIN_API_NAME@ </name>
   <version> @pkg_semver@ </version>


### PR DESCRIPTION
A new stab on #193 which:
  - Adds a link to the build log as a comment in the metadata files.
  - Cleans up the filename for tagged builds, basically just using the tag as identifier (besides target platform).
  - Allow overwrites when uploading, last upload wins if there are two files with the same name.

Everything should still be possible to trace, the auto branch will have copies of all versions of the metadata files since the build comment differs.

We need to think more about this.... Thoughts?