### PR TITLE
libs/jsoncpp: Dont use system library by default.

### DIFF
--- a/libs/jsoncpp/CMakeLists.txt
+++ b/libs/jsoncpp/CMakeLists.txt
@@ -5,7 +5,7 @@ endif ()
 cmake_minimum_required(VERSION 3.1.0)
 project("jsoncpp")
 
-option(USE_SYSTEM_JSONCPP "Use system copy of library if available" ON)
+option(USE_SYSTEM_JSONCPP "Use system copy of library if available" OFF)
 
 add_library(_JSONCPP INTERFACE)
 add_library(ocpn::jsoncpp ALIAS _JSONCPP)


### PR DESCRIPTION
As I suspected the linkage error was simple bug. I have not built this, so we need to wait for builders before merging.