### PR TITLE
Update-templates: Update (#201)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 po/*.pot
-.DS_store
+.DS_Store
+thumbs.db

--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -3,7 +3,7 @@ updates-templates README
 
 The script update-templates can be used to update a plugin with
 newer versions of the shipdriver templates. The basic workflow
-is to 
+is to
 
   - Make sure the plugin repo is clean (commit or stash changes)
   - Download the script
@@ -20,7 +20,7 @@ Linux:
     $ repo=https://raw.githubusercontent.com/leamas/shipdriver_pi/update-164
     $ curl $repo/update-templates --output update-templates
 
-It is also possible to use wget instead of curl, like 
+It is also possible to use wget instead of curl, like
 `wget $repo/update-templates`.
 
 
@@ -43,6 +43,15 @@ The script is run from the plugin top directory using
 `bash ./update-templates`. In windows, assuming standard installation paths:
 
     > "C:\Program Files\Git\bin\bash.exe" update-templates
+
+There are two options:
+  - *-t treeish*
+       The source treeish in the shipdriver repository. Defaults to
+       *shipdriver/master*
+  - *-b branch*
+       The destination branch where changes are merged. Defaults to
+       *main* if it exists, otherwise *master*
+
 
 
 Inspecting results and committing
@@ -68,11 +77,9 @@ When all looks good changes can be committed using something like
 `git commit -m "Update shipdriver templates."`
 
 
+
 Pin files which should not be updated
 -------------------------------------
 
 The script supports a file named *update-ignored*. This is a list of files,
 one per line, which should not be updated in any case.
-
-
-

--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -44,13 +44,9 @@ The script is run from the plugin top directory using
 
     > "C:\Program Files\Git\bin\bash.exe" update-templates
 
-There are two options:
-  - *-t treeish*
-       The source treeish in the shipdriver repository. Defaults to
-       *shipdriver/master*
-  - *-b branch*
-       The destination branch where changes are merged. Defaults to
-       *main* if it exists, otherwise *master*
+There is an optional argument, a shipdriver treeish. To merge changes
+from a shipdriver tag, use `bash ./update-templates <tag>`. One can
+also use a shipdriver commit instead of a tag.
 
 
 

--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -68,7 +68,11 @@ When all looks good changes can be committed using something like
 `git commit -m "Update shipdriver templates."`
 
 
+Pin files which should not be updated
+-------------------------------------
 
+The script supports a file named *update-ignored*. This is a list of files,
+one per line, which should not be updated in any case.
 
 
 

--- a/update-templates
+++ b/update-templates
@@ -2,18 +2,14 @@
 #
 # Update a plugin with new sipdriver templates.
 #
-# usage: ./update-templates [branch]
+# usage: ./update-templates [treeish]
 #
-# Merge changes from upstream shipdriver repo into a
-# given branch, by default 'main' or 'master'.
+# Merge changes from upstream shipdriver repo into
+# current branch.
 #
 # See UPDATE-TEMPLATES.md for more info
 
-
-# The tip we merge into the plugin, possibly a shipdriver tag or commit.
-source_treeish="shipdriver/master"
-
-
+source_treeish=${1:-"shipdriver/master"}
 
 # Refuse to run unless the index is clean:
 clean=$(git status --porcelain | grep -v update-template)
@@ -22,14 +18,6 @@ if [ -n "$clean" ]; then
     exit 1
 fi
 
-# We use the shipdriver.master branch as merging point. Make sure
-# user dont already have anything here.
-if git show-ref --verify --quiet refs/heads/shipdriver.master; then
-    echo "The branch shipdriver.master is in the way, please remove"  >&2
-    exit 1
-fi 
-
-
 # Set up the shipdriver remote
 if git ls-remote --exit-code shipdriver &>/dev/null; then
     git remote remove shipdriver
@@ -37,23 +25,8 @@ if git ls-remote --exit-code shipdriver &>/dev/null; then
 fi
 git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
 git remote update shipdriver
-git fetch --tags shipdriver
 
-
-# Determine the branch to be merged with fresh templates
-if git show-ref --verify --quiet refs/heads/${1:-'main'}; then
-    branch="${1:-'main'}"
-elif git show-ref --verify --quiet refs/heads/master; then
-    branch='master'
-else
-    "Cannot determine a usable branch to merge. Giving up."
-fi
-
-echo "Merging changes into branch $branch"
-
-
-# Merge all changes in shipdriver remote with current status
-git checkout $branch
+# Merge all changes in shipdriver remote with current branch
 git merge --no-ff --no-commit --allow-unrelated-histories -X theirs \
     $source_treeish
 
@@ -79,7 +52,7 @@ do
     for ff in $(git status --porcelain $f \
                 | grep -E "A? $f" | awk '{print $2}')
     do
-        git rm -f $ff
+        git rm --quiet -f $ff
     done
 done
 
@@ -88,7 +61,7 @@ for f in $(git status --porcelain \
            | grep -E "A.*enc|A.*pub|A.*fbp" \
            | awk '{print $2}')
 do
-    git rm -f $f
+    git rm -f --quiet $f
 done
 
 # Revert changes in blacklisted files.
@@ -100,12 +73,12 @@ fi
 
 # Create or update version file
 date  "+%Y-%m-%d %H:%M" > cmake/TemplateVersion
-commit=$(git rev-parse --short shipdriver/master)
+commit=$(git rev-parse --short $source_treeish)
 echo "commit: $commit" >> cmake/TemplateVersion
 tags=$(git tag --contains $commit)
 echo "tags: $tags" >> cmake/TemplateVersion
 git add cmake/TemplateVersion
-    
+
 
 cat << EOF
 Shipdriver templates have been updated. To review pending changes:
@@ -113,12 +86,5 @@ Shipdriver templates have been updated. To review pending changes:
     $ git status
     $ git diff --staged
 
-To reset a file to state before merging the templates:
-
-    $ git checkout HEAD <file>
-
-Changes can be committed using
-
-    $ git commit -m "Update shipdriver templates."
-
+See UPDATE_TEMPLATES.md for more.
 EOF

--- a/update-templates
+++ b/update-templates
@@ -25,6 +25,7 @@ if git ls-remote --exit-code shipdriver &>/dev/null; then
 fi
 git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
 git remote update shipdriver
+git fetch --tags shipdriver
 
 # Merge all changes in shipdriver remote with current branch
 git merge --no-ff --no-commit --allow-unrelated-histories -X theirs \

--- a/update-templates
+++ b/update-templates
@@ -10,6 +10,10 @@
 # See UPDATE-TEMPLATES.md for more info
 
 
+# The tip we merge into the plugin, possibly a shipdriver tag or commit.
+source_treeish="shipdriver/master"
+
+
 
 # Refuse to run unless the index is clean:
 clean=$(git status --porcelain | grep -v update-template)
@@ -33,6 +37,7 @@ if git ls-remote --exit-code shipdriver &>/dev/null; then
 fi
 git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
 git remote update shipdriver
+git fetch --tags shipdriver
 
 
 # Determine the branch to be merged with fresh templates
@@ -48,10 +53,9 @@ echo "Merging changes into branch $branch"
 
 
 # Merge all changes in shipdriver remote with current status
-git fetch shipdriver master:shipdriver.master
 git checkout $branch
 git merge --no-ff --no-commit --allow-unrelated-histories -X theirs \
-    shipdriver.master
+    $source_treeish
 
 # Restore all non-template files.
 for f in \
@@ -86,6 +90,13 @@ for f in $(git status --porcelain \
 do
     git rm -f $f
 done
+
+# Revert changes in blacklisted files.
+if [ -e update-ignored ]; then
+    for f in $(cat update-ignored); do
+        git checkout HEAD $f
+    done
+fi
 
 # Create or update version file
 date  "+%Y-%m-%d %H:%M" > cmake/TemplateVersion

--- a/update-templates
+++ b/update-templates
@@ -73,7 +73,8 @@ if [ -e update-ignored ]; then
 fi
 
 # Create or update version file
-date  "+%Y-%m-%d %H:%M" > cmake/TemplateVersion
+echo "# Created by update-templates" > cmake/TemplateVersion
+echo "date: $(date -u +'%Y-%m-%d %H:%M UTC')" >> cmake/TemplateVersion
 commit=$(git rev-parse --short $source_treeish)
 echo "commit: $commit" >> cmake/TemplateVersion
 tags=$(git tag --contains $commit)

--- a/update-templates
+++ b/update-templates
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# Update a plugin with new sipdriver templates.
+# Update a plugin with new shipdriver templates.
 #
 # usage: ./update-templates [treeish]
 #


### PR DESCRIPTION
Close some open issues:

  - Update bootstrap info to reflect that script is merged into rasbats/shipdriver
  - Add  a provisionary UPDATE_TEMPLATES.md document.
  - Add some windows usage notes
  - Support a blacklist (update-ignored) which lists files which should not be updated.
  - Use current branch rather than hardcoded master as the branch merging changes
  - Add a *treeish* option to script so one can merge changes from a specific shipdriver commit or tag rather than just shipdriver/master.
 
While on it: some .gitignore updates.

See: #201