### PR TITLE
Update rev3 (#201)

### DIFF
--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -6,48 +6,59 @@ newer versions of the shipdriver templates. The basic workflow
 is to
 
   - Make sure the plugin repo is clean (commit or stash changes)
-  - Download the script
-  - Run it
+  - Bootstrap process by downloading script and add it to repo.
+  - Run script
   - Inspect the results, handle possible conflicts and commit the
     changes.
 
 
-Downloading
------------
+Bootstrapping
+-------------
+Only required if the update script is yet not part of the repo. Once
+installed, the script is self-updating.
+
 Linux:
 
     $ cd some_plugin
-    $ repo=https://raw.githubusercontent.com/leamas/shipdriver_pi/update-164
+    $ repo=https://raw.githubusercontent.com/Rasbats/shipdriver_pi/master
     $ curl $repo/update-templates --output update-templates
+    $ chmod 755 update-templates
+    $ git add update-templates
+    $ git commit -m "Add update-templates script"
 
 It is also possible to use wget instead of curl, like
 `wget $repo/update-templates`.
 
 
-Downloading - Windows
----------------------
+Bootstrap - Windows
+-------------------
+
+As in linux, bootstrapping is only required if the script is yet not
+available in the plugin repo. Once installed, it's self-updating.
 
 The script is written in bash, so git-bash is required. Using git-bash, the
-script can be run as in Linux, see above.
+script can be downloaded and installed as in linux, see above.
 
-Using the command CLI goes like:
+Using the Windows command CLI goes like:
 
     > cd some_plugin
-    > set repo=https://raw.githubusercontent.com/leamas/shipdriver_pi/update-164
+    > set repo=https://raw.githubusercontent.com/Rasbats/shipdriver_pi/master
     > curl %repo%/update-templates --output update-templates
+    > git add update-templates
+    > git commit -m "Add update-templates script"
+
 
 Running
 -------
 
 The script is run from the plugin top directory using
-`bash ./update-templates`. In windows, assuming standard installation paths:
+`./update-templates`. In windows, assuming standard installation paths:
 
     > "C:\Program Files\Git\bin\bash.exe" update-templates
 
 There is an optional argument, a shipdriver treeish. To merge changes
-from a shipdriver tag, use `bash ./update-templates <tag>`. One can
+from a shipdriver tag, use `./update-templates <tag>`. One can
 also use a shipdriver commit instead of a tag.
-
 
 
 Inspecting results and committing

--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -56,9 +56,19 @@ The script is run from the plugin top directory using
 
     > "C:\Program Files\Git\bin\bash.exe" update-templates
 
-There is an optional argument, a shipdriver treeish. To merge changes
-from a shipdriver tag, use `./update-templates <tag>`. One can
-also use a shipdriver commit instead of a tag.
+Usage summary:
+
+    update-templates [-t] [treeish]
+
+The *-t* option adds a *-X theirs* to the git merge performed. It will 
+resolve all conflicts by using the upstream shipdriver stuff. By default,
+the conflicts will be unresolved in the results.
+
+The *treeish* option can be used to merge changes from another shipdriver
+state than the default shipdriver/master i. e., a tag or a commit from
+the shipdriver repo.
+
+*update-templates -h* prints the complete help message.
 
 
 Inspecting results and committing

--- a/update-templates
+++ b/update-templates
@@ -50,17 +50,14 @@ for f in \
 do
     if test -e "$f"; then git checkout HEAD $f; fi
     # Remove all added files in local directories
-    for ff in $(git status --porcelain $f \
-                | grep -E "A? $f" | awk '{print $2}')
-    do
+    for ff in $(git diff --diff-filter=AC --name-only --staged $f); do
         git rm --quiet -f $ff
     done
 done
 
 # Remove miscellaneous added files
-for f in $(git status --porcelain \
-           | grep -E "A.*enc|A.*pub|A.*fbp" \
-           | awk '{print $2}')
+for f in $(git diff --diff-filter=AC --name-only --staged \
+           | grep -E "\.enc$|\.pub$|\.fbp$")
 do
     git rm -f --quiet $f
 done

--- a/update-templates
+++ b/update-templates
@@ -48,11 +48,13 @@ for f in \
     README.md \
     src
 do
-    if test -e "$f"; then git checkout HEAD $f; fi
-    # Remove all added files in local directories
-    for ff in $(git diff --diff-filter=AC --name-only --staged $f); do
-        git rm --quiet -f $ff
-    done
+    if test -e "$f"; then
+        git checkout HEAD $f
+        # Remove all added files in local directories
+        for ff in $(git diff --diff-filter=AC --name-only --staged $f); do
+            git rm --quiet -f $ff
+        done
+    fi
 done
 
 # Remove miscellaneous added files

--- a/update-templates
+++ b/update-templates
@@ -2,18 +2,50 @@
 #
 # Update a plugin with new shipdriver templates.
 #
-# usage: ./update-templates [treeish]
+# usage: ./update-templates [-t] [treeish]
 #
 # Merge changes from upstream shipdriver repo into
 # current branch.
 #
 # See UPDATE-TEMPLATES.md for more info
 
+function usage() {
+    cat << EOT
+Usage: update-templates [-t] [-T] [-h] [treeish]
+
+Parameters:
+    treeish:
+         A shipdriver tag, branch or commit, defaults to shipdriver/master
+
+Options:
+    -t   Add a -X theirs to git-merge(1)
+    -T   Test mode, do not auto-update
+    -h   Print this message and exit
+EOT
+}
+
+# Handle options and parameters
+usage="Usage: $0 [-t] [-T] [treeish]"
+merge_opt=""
+while getopts "tTh" opt; do
+    case "${opt}" in
+        t)  merge_opt="-X theirs"
+            ;;
+        T)  test_mode=true
+            ;;
+        h)  usage; exit 0
+            ;;
+        *)  usage >&2; exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
 source_treeish=${1:-"shipdriver/master"}
+
 
 # Refuse to run unless the index is clean:
 clean=$(git status --porcelain)
-if [ -n "$clean" ]; then 
+if [ -n "$clean" ]; then
     echo "Please commit or stash pending changes. Aborting."
     exit 1
 fi
@@ -30,18 +62,20 @@ git fetch --tags shipdriver
 
 
 # If we need to update this script, do it and exit
-if ! git diff --quiet HEAD $source_treeish -- update-templates; then
-    git checkout $source_treeish update-templates
-    cat << EOT
+if [ -z "$test_mode" ]; then
+    if ! git diff --quiet HEAD $source_treeish -- update-templates; then
+        git checkout $source_treeish update-templates
+        cat << EOT
 update-templates script is updated to latest version. Please commit
 changes and re-run script.
 EOT
-    exit 0
+        exit 0
+    fi
 fi
 
 
 # Merge all changes in shipdriver remote with current branch
-git merge --no-ff --no-commit --allow-unrelated-histories -X theirs \
+git merge --no-ff --no-commit --allow-unrelated-histories $merge_opt \
     $source_treeish
 
 

--- a/update-templates
+++ b/update-templates
@@ -12,11 +12,12 @@
 source_treeish=${1:-"shipdriver/master"}
 
 # Refuse to run unless the index is clean:
-clean=$(git status --porcelain | grep -v update-template)
+clean=$(git status --porcelain)
 if [ -n "$clean" ]; then 
     echo "Please commit or stash pending changes. Aborting."
     exit 1
 fi
+
 
 # Set up the shipdriver remote
 if git ls-remote --exit-code shipdriver &>/dev/null; then
@@ -27,9 +28,22 @@ git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
 git remote update shipdriver
 git fetch --tags shipdriver
 
+
+# If we need to update this script, do it and exit
+if ! git diff --quiet HEAD $source_treeish -- update-templates; then
+    git checkout $source_treeish update-templates
+    cat << EOT
+update-templates script is updated to latest version. Please commit
+changes and re-run script.
+EOT
+    exit 0
+fi
+
+
 # Merge all changes in shipdriver remote with current branch
 git merge --no-ff --no-commit --allow-unrelated-histories -X theirs \
     $source_treeish
+
 
 # Restore all non-template files.
 for f in \
@@ -57,6 +71,7 @@ do
     fi
 done
 
+
 # Remove miscellaneous added files
 for f in $(git diff --diff-filter=AC --name-only --staged \
            | grep -E "\.enc$|\.pub$|\.fbp$")
@@ -64,12 +79,14 @@ do
     git rm -f --quiet $f
 done
 
+
 # Revert changes in blacklisted files.
 if [ -e update-ignored ]; then
     for f in $(cat update-ignored); do
         git checkout HEAD $f
     done
 fi
+
 
 # Create or update version file
 echo "# Created by update-templates" > cmake/TemplateVersion


### PR DESCRIPTION
Added what I think is the last missing pieces (?):

  - Added a -t option and changed the default setup to don't use `-X theirs`. *update-templates -t* basically does the same thing as *update-templates* before the change. See UPDATE-TEMPLATES.md
  - Added self-updating. This means that we add the update script to the plugin repos, but the script will update itself before running.  I think it's pretty easy to use and also avoids complicated curl commands except for the first time.  It make things sane since the repo is totally clean when running the update. More in UPDATES-TEMPLATES
  - Bugfixes and cleanup.,

  
