### PR TITLE
Ci: Flatpak: Avoid using outdated TLS certificates (210)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,19 +55,7 @@ set(OCPN_RELEASE_REPO
 )
 option(SHIPDRIVER_USE_SVG "Use SVG graphics" ON)
 
-set(OCPN_TARGET_TUPLE "" CACHE STRING
-  "Target spec: \"platform;version;arch\""
-)
-
-string(TOLOWER "${OCPN_TARGET_TUPLE}" _lc_target)
-if ("${_lc_target}" MATCHES "android*")
-  set(QT_ANDROID ON)
-  # Until we have a proper toolchain file:
-  set(CMAKE_CROSSCOMPILING ON)
-else ()
-  set(QT_ANDROID OFF)
-  add_definitions(-D__OCPN_USE_CURL__)
-endif ()
+include(PluginOptions)
 #
 #
 # -------  Plugin setup --------

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -12,6 +12,9 @@ set -x
 sudo apt update
 
 
+# Avoid using outdated TLS certificates, see #210.
+sudo apt install --reinstall  ca-certificates
+
 # Install flatpak and flatpak-builder
 sudo apt install flatpak flatpak-builder
 flatpak remote-add --user --if-not-exists \

--- a/cmake/PluginOptions.cmake
+++ b/cmake/PluginOptions.cmake
@@ -1,0 +1,36 @@
+if (DEFINED _default_build_type)
+  return ()
+endif ()
+
+# Set a default build type if none was specified
+# https://blog.kitware.com/cmake-and-the-default-build-type/
+set(_default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(_default_build_type "Debug")
+endif()
+ 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS
+    "Setting build type to '${_default_build_type}' as none was specified."
+  )
+  set(CMAKE_BUILD_TYPE "${_default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Set up OCPN_TARGET_TUPLE and update QT_ANDROID accordingly
+set(OCPN_TARGET_TUPLE "" CACHE STRING
+  "Target spec: \"platform;version;arch\""
+)
+
+string(TOLOWER "${OCPN_TARGET_TUPLE}" _lc_target)
+if ("${_lc_target}" MATCHES "android*")
+  set(QT_ANDROID ON)
+  # Until we have a proper toolchain file:
+  set(CMAKE_CROSSCOMPILING ON)
+else ()
+  set(QT_ANDROID OFF)
+  add_definitions(-D__OCPN_USE_CURL__)
+endif ()

--- a/update-templates
+++ b/update-templates
@@ -40,6 +40,8 @@ while getopts "tTh" opt; do
     esac
 done
 shift $((OPTIND-1))
+
+set -x
 source_treeish=${1:-"shipdriver/master"}
 
 
@@ -50,28 +52,34 @@ if [ -n "$clean" ]; then
     exit 1
 fi
 
-
-# Set up the shipdriver remote
-if git ls-remote --exit-code shipdriver &>/dev/null; then
-    git remote remove shipdriver
-    echo "Removing existing shipdriver remote."
-fi
-git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
-git remote update shipdriver
-git fetch --tags shipdriver
-
-
-# If we need to update this script, do it and exit
-if [ -z "$test_mode" ]; then
-    if ! git diff --quiet HEAD $source_treeish -- update-templates; then
-        git checkout $source_treeish update-templates
-        cat << EOT
+if [ -z "$UPDATE_TEST" ]; then
+    # Set up the shipdriver remote
+    if git ls-remote --exit-code shipdriver &>/dev/null; then
+        git remote remove shipdriver
+        echo "Removing existing shipdriver remote."
+    fi
+    git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
+    git remote update shipdriver
+    git fetch --tags shipdriver
+    
+    # Create a new update branch and work on that
+    hash=$(git rev-parse --short  $source_treeish)
+    new_branch="update.$hash"
+    if git rev-parse $new_branch &> /dev/null; then git branch -D $new_branch; fi
+    git branch $new_branch $source_treeish 
+    
+    # If we need to update this script, do it and exit
+    if [ -z "$test_mode" ]; then
+        if ! git diff --quiet HEAD $source_treeish -- update-templates; then
+            git checkout $source_treeish update-templates
+            cat << EOT
 update-templates script is updated to latest version. Please commit
 changes and re-run script.
 EOT
-        exit 0
+            exit 0
+        fi
     fi
-fi
+fi 
 
 
 # Merge all changes in shipdriver remote with current branch

--- a/update-templates
+++ b/update-templates
@@ -121,6 +121,11 @@ if [ -e update-ignored ]; then
     done
 fi
 
+# Add files which are simple additions
+for f in $(git diff --staged --name-only --diff-filter=A); do
+    git add $f
+done
+
 
 # Create or update version file
 echo "# Created by update-templates" > cmake/TemplateVersion


### PR DESCRIPTION
As heading says. Update TLS certificates used in order to avoid problems described in https://github.com/OpenCPN/OpenCPN/issues/2419

Closes: #210