### PR TITLE
update-templates: Handle windows file lock on update.

### DIFF
--- a/update-templates
+++ b/update-templates
@@ -24,6 +24,14 @@ Options:
 EOT
 }
 
+# Exec on tmpfile to avoid file lock when updating script on Windows.
+# The directory /c exists on git bash on Windows, and hopefully only there.
+if [[ -d /c && "$0" =~ .*update-templates ]]; then
+    tmpfile=$(mktemp)
+    cp $0 $tmpfile
+    exec $tmpfile
+fi
+
 # Handle options and parameters
 usage="Usage: $0 [-t] [-T] [treeish]"
 merge_opt=""


### PR DESCRIPTION
Run script from a temporary copy on windows to avoid lock problems whne self-updating script.

Ony on windows. Leaves copies of file as temporaries around. Hard to fix since silly windows does not allow write or delete for a file executed.