### PR TITLE
update-templates: Handle upstream changes in CMakelists etc.

### DIFF
--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -106,37 +106,20 @@ changes.  A typical sequence is
     $ git diff HEAD upstream/master ci           # list the actual diff(s)
     $ git checkout upstream/master ci            # Accept all changes
 
-Note that changes might be required in other files like CMakeLists.txt.
-
 When all looks good changes can be committed using something like
 `git commit -m "Update shipdriver templates."`
 
-Checking modifications in CMakeLists.txt
-----------------------------------------
+Checking modifications in CMakeLists.txt and flatpak manifest
+-------------------------------------------------------------
 
 Besides the changes in generic files, CMakeLists.txt typically also needs to
 be updated. However, this file is specific for each plugin, and changes must
 be applied manually.
 
 The changes made in shipdriver's CMakeLists.txt is a good starting point to
-check. To display these changes first checkout the shipdriver master branch:
-
-    $ git fetch shipdriver master:shipdriver/master
-    $ git checkout shipdriver/master
-
-The tag used when last updating templates is available in the file 
-_cmake/TemplateVersion_. If this file does not exist, list all tags and
-select one to compare against
-
-    $ git tag -l
-
-See all changes in CMakeLists.txt since selected tag (here v2.6.1.0):
-
-    $ git diff v2.6.1.0 CMakeLists.txt
-
-See list of files changed since selected tag (again, v2.6.1.0):
-
-    $ git diff --stat v2.6.1.0
+check. Af running the script these changes are appended as a comment to
+CMakeLists.txt. Reviewing these changes should give a good hint about the
+changes needed. After review, remove the diff comment.
 
 
 Upstreaming local changes to shipdriver

--- a/update-templates
+++ b/update-templates
@@ -142,6 +142,23 @@ for f in $(git diff --staged --name-only --diff-filter=A); do
     git add $f
 done
 
+# Add diff for upstream's CMakeLists.txt as comment here:
+if [ -f cmake/Templateversion ]; then
+    prev_commit=$(sed -n '/commit:/s/.*: *//p' cmake/TemplateVersion)
+else
+    prev_commit='v2.6.2.0'
+fi
+git diff $prev_commit $source_treeish CMakeLists.txt | sed 's/^/# /' \
+    >>  CMakeLists.txt
+
+# Same diff comment for the flatpak manifest:
+src_manifest=flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+our_manifest=$(echo flatpak/org.opencpn.OpenCPN.Plugin.*.yaml)
+git checkout $source_treeish $src_manifest
+git diff $prev_commit $source_treeish $src_manifest | sed 's/^/# /' \
+    >> $our_manifest
+git rm -f $src_manifest
+
 
 # Create or update version file
 echo "# Created by update-templates" > cmake/TemplateVersion


### PR DESCRIPTION
For CMakeLists and the flatpak manifest: add the changes in the
upstream shipdriver file as comments to the downstream variants
as help to fo update these.

This is basically to automate the instructions in UPDATE-TEMPLATES which thus  are simplified.