### PR TITLE
update-templates: Handle generic/non-generic libs  (#242)

### DIFF
--- a/update-templates
+++ b/update-templates
@@ -105,7 +105,6 @@ for f in \
     COPYING \
     data \
     flatpak \
-    libs \
     manual \
     mingw \
     po \
@@ -119,6 +118,17 @@ do
             git rm --quiet -f $ff
         done
     fi
+done
+
+# Restore private libraries in libs, but not the generic ones
+for d in libs/*; do
+    case "$d" in
+      api*|AndroidHeaders)
+          continue
+          ;;
+      *)  git checkout HEAD $d
+          ;;
+    esac
 done
 
 


### PR DESCRIPTION
Hard-code the list of generic libs in the update script rather
than a possibly over-engineered generic  solution. Logic by default
treats libraries as private.

Closes: #242