### PR TITLE
ci: macos: New deployment target 10.10 (#286)

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -13,7 +13,7 @@
 
 set -xe
 
-export MACOSX_DEPLOYMENT_TARGET=10.9
+export MACOSX_DEPLOYMENT_TARGET=10.10
 
 # Return latest version of $1, optiomally using option $2
 pkg_version() { brew list --versions $2 $1 | tail -1 | awk '{print $2}'; }


### PR DESCRIPTION
Update deployment target after discussions in upstream bug.

Closes: #286