### PR TITLE
Avoid hard-coded flatpak manifest path (#289)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,11 @@ endif ()
 # 'flatpak', 'android' or 'tarball'. The initial call without BUILD_TYPE ends
 # here.
 #
-include(Targets)
-create_targets(
-  ${PROJECT_SOURCE_DIR}/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+file(GLOB FLATPAK_MANIFEST
+  ${PROJECT_SOURCE_DIR}/flatpak/org.opencpn.OpenCPN.Plugin.*.yaml
 )
+include(Targets)
+create_targets(${FLATPAK_MANIFEST})
 if ("${BUILD_TYPE}" STREQUAL "")
   return ()
 endif ()


### PR DESCRIPTION
... glob it instead. Might fail if user has multiple matches, but that seems very unlikely

Closes: #289