### PR TITLE
ci: macos: Dont forget to initialize submodule.

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -36,6 +36,7 @@ wget -q https://download.opencpn.org/s/MCiRiq4fJcKD56r/download \
 tar -C /tmp -xJf /tmp/wx315_opencpn50_macos1010.tar.xz
 
 # Build and package
+git submodule update --init opencpn-libs
 rm -rf build && mkdir build && cd build
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
@@ -51,7 +52,6 @@ if [[ -z "$CI" ]]; then
     exit 0
 fi
 
-git submodule update --init opencpn-libs
 make VERBOSE=1 tarball
 
 # Install cloudsmith needed by upload script


### PR DESCRIPTION
Fix builds for macos (did git submodule update --init at the wrong point.)