### PR TITLE
ci: circleci: Limit CPUs used (#301).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: flatpak-arm64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     parameters:
       cache-key:
         type: string
@@ -47,6 +48,7 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: flatpak-arm64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     parameters:
       cache-key:
         type: string
@@ -58,6 +60,7 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
       - BUILD_1808: "true"
     parameters:
       cache-key:
@@ -70,6 +73,7 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     parameters:
       cache-key:
         type: string
@@ -82,6 +86,7 @@ jobs:
       xcode: "12.5.1"
     environment:
       - OCPN_TARGET: macos
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
       - run: ci/circleci-build-macos.sh
@@ -94,6 +99,7 @@ jobs:
       - image: circleci/buildpack-deps:xenial-scm
     environment:
       - OCPN_TARGET: xenial
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
       - USE_DEADSNAKES_PY37: 1
     <<: *debian-steps
 
@@ -102,6 +108,7 @@ jobs:
       - image: circleci/buildpack-deps:bionic-scm
     environment:
       - OCPN_TARGET: bionic
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
   build-bionic-gtk3:
@@ -109,6 +116,7 @@ jobs:
       - image: circleci/buildpack-deps:bionic-scm
     environment:
       - BUILD_GTK3: true
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
       - OCPN_TARGET: bionic-gtk3
     <<: *debian-steps
 
@@ -117,6 +125,7 @@ jobs:
       - image: circleci/buildpack-deps:focal-scm
     environment:
       - OCPN_TARGET: focal
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
   build-buster:
@@ -124,6 +133,7 @@ jobs:
       - image: circleci/buildpack-deps:buster-scm
     environment:
       - OCPN_TARGET: buster
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
   build-android-arm64:
@@ -131,6 +141,7 @@ jobs:
       - image: circleci/android:api-28-ndk
     environment:
       - OCPN_TARGET: android-aarch64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
       - run: ci/circleci-build-android.sh
@@ -142,6 +153,7 @@ jobs:
       - image: circleci/android:api-28-ndk
     environment:
       - OCPN_TARGET: android-armhf
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
       - run: ci/circleci-build-android.sh


### PR DESCRIPTION
For circleci, limit the number of CPUs used to 2.

The underlying problem here is a bug in docker which when client asks for number of CPU:s available get the total number of CPUs in the host rather the cpu count available in the docker guest. Not much to do than to manually limit.

Closes: #301