### PR TITLE
jsoncpp: Apply patch muting bogus diagnostics (#288).

### DIFF
--- a/libs/jsoncpp/CMakeLists.txt
+++ b/libs/jsoncpp/CMakeLists.txt
@@ -13,15 +13,6 @@ project("jsoncpp")
 
 option(USE_SYSTEM_JSONCPP "Use system copy of library if available" OFF)
 
-find_program(GIT NAMES git)
-if (GIT)
-  file(GLOB PATCHFILE 0001*patch)
-  execute_process(
-    COMMAND git apply -p3 --directory libs/jsoncpp ${PATCHFILE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  )
-endif ()
-
 add_library(_JSONCPP INTERFACE)
 add_library(ocpn::jsoncpp ALIAS _JSONCPP)
 

--- a/libs/jsoncpp/src/lib_json/json_reader.cpp
+++ b/libs/jsoncpp/src/lib_json/json_reader.cpp
@@ -753,11 +753,17 @@ bool Reader::addErrorAndRecover(const String& message, Token& token,
 
 Value& Reader::currentValue() { return *(nodes_.top()); }
 
+// https://github.com/open-source-parsers/jsoncpp/issues/1188
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 Reader::Char Reader::getNextChar() {
   if (current_ == end_)
     return 0;
   return *current_++;
 }
+
+#pragma GCC diagnostic pop
 
 void Reader::getLocationLineAndColumn(Location location, int& line,
                                       int& column) const {
@@ -794,6 +800,7 @@ String Reader::getFormatedErrorMessages() const {
   return getFormattedErrorMessages();
 }
 
+
 String Reader::getFormattedErrorMessages() const {
   String formattedMessage;
   for (const auto& error : errors_) {
@@ -807,6 +814,10 @@ String Reader::getFormattedErrorMessages() const {
   return formattedMessage;
 }
 
+// https://github.com/open-source-parsers/jsoncpp/issues/1188
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   std::vector<Reader::StructuredError> allErrors;
   for (const auto& error : errors_) {
@@ -818,6 +829,8 @@ std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   }
   return allErrors;
 }
+
+#pragma GCC diagnostic pop
 
 bool Reader::pushError(const Value& value, const String& message) {
   ptrdiff_t const length = end_ - begin_;


### PR DESCRIPTION
Back-port fix for the build error in jsoncpp from #298