### PR TITLE
build: Don't use --config for cmake configuration (#310).

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,5 +39,6 @@ To build an android armhf tarball
 On windows, a different workflow is used:
 
     > ..\buildwin\win_deps.bat
-    > cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+    > cmake -T v141_xp -G "Visual Studio 15 2017" ^
+           -DCMAKE_BUILD_TYPE=RelWithDebInfo  ..
     > cmake --build . --target tarball --config RelWithDebInfo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,9 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+  - >
+    cmake -T v141_xp -G "Visual Studio 15 2017"
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo  ..
   - cmake --build . --target tarball --config RelWithDebInfo
   - py ..\ci\windows-ldd
   - cmd: upload.bat

--- a/buildwin/ShipDriver.clone.bat
+++ b/buildwin/ShipDriver.clone.bat
@@ -18,7 +18,7 @@ cd shipdriver_pi
 mkdir  build
 cd build
 cmake -T v141_xp ..
-cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build . --target tarball --config RelWithDebInfo
 
 cmd /k

--- a/buildwin/ShipDriver.without.clone.bat
+++ b/buildwin/ShipDriver.without.clone.bat
@@ -14,7 +14,7 @@ cd shipdriver_pi
 mkdir  build
 cd build
 cmake -T v141_xp ..
-cmake -G "Visual Studio 15 2017" --config RelWithDebInfo  ..
+cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=RelWithDebInfo  ..
 cmake --build . --target tarball --config RelWithDebInfo
 
 cmd /k


### PR DESCRIPTION
Recent cmake (3.21?) does not accept the --config option when
configuring. Replace with  the proper -DCMAKE_BUILD_TYPE which
also has been solving problems in calculator_pi.

Closes: #310