### PR TITLE
#312: Move temporaries to project cache directory.

### DIFF
--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -10,12 +10,10 @@ rem
 python --version > nul 2>&1 && python -m ensurepip > nul 2>&1
 if errorlevel 1 (
    choco install -y python
-   refreshenv
 )
 cmake --version > nul 2>&1
 if errorlevel 1 (
    choco install -y cmake
-   refreshenv
 )
 python --version
 python -m ensurepip
@@ -24,7 +22,9 @@ python -m pip install -q setuptools wheel
 python -m pip install -q cloudsmith-cli
 python -m pip install -q cryptography
 
-set WXWIN=C:\wxWidgets-3.1.2
+set SCRIPTDIR=%~dp0
+set WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.1.2
+
 set wxWidgets_ROOT_DIR=%WXWIN%
 set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
 SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%
@@ -40,3 +40,5 @@ if not exist "C:\Program Files (x86)\Poedit" (
 )
 SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin
 SET PATH=%PATH%;C:\Program Files (x86)\Poedit
+
+refreshenv

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -182,8 +182,9 @@ function (flatpak_target manifest)
   set(_fp_script "
     execute_process(
       COMMAND
-        flatpak-builder --force-clean ${CMAKE_CURRENT_BINARY_DIR}/app
-          ${manifest}
+        flatpak-builder
+          --state-dir ${CMAKE_SOURCE_DIR}/cache/flatpak --force-clean
+          ${CMAKE_CURRENT_BINARY_DIR}/app ${manifest}
     )
     execute_process(
       COMMAND bash -c \"sed -e '/@checksum@/d' \


### PR DESCRIPTION
Make flatpak, windows and since earlier Android builds us a common cache directory for downloads and other state. This means that the cache persists even if the build directory is cleared and also avoids cluttering for example c:/ top directory with various downloads.

Might be other things to handle before closing #312, but this should be a good starter. Builds on all hosts and does not cause any changed behaviour in local builds.