### PR TITLE
CMakeLists: Only link libjsoncpp if not done by Plugin.gl (#330).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,13 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
 
   include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
 
-  if (EXISTS "libs/jsoncpp")
-    add_subdirectory("libs/jsoncpp")
-    target_link_libraries(${PACKAGE_NAME} ocpn::jsoncpp)
-  endif ()
-
   if (COMMAND add_plugin_libraries)
     add_plugin_libraries()
+  endif ()
+
+  if (EXISTS "libs/jsoncpp" AND NOT TARGET ocpn::jsoncpp)
+    add_subdirectory("libs/jsoncpp")
+    target_link_libraries(${PACKAGE_NAME} ocpn::jsoncpp)
   endif ()
 
 endif ()


### PR DESCRIPTION
This should be acceptable as a clean bugfix. It will not add the
wxjson subdirectory twice, the root problem in #330.

The catch is that semantics will change: A plugin which links to
jsoncpp will fail since josncpp will not be visible until all plugins
are linked.

However, I'm not aware of any plugin which depends on jsoncpp. And
if there indeed is such a plugin, it can be handled by Plugin.gl
by adding jsoncpp before. This is a lesser evil than the current #330
situation

Closes: #330 -- the repeated build issue reported there is in #331