### PR TITLE
Updates to master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ else ()
   message(STATUS "Configuring")
 endif ()
 
+# -------- Plugin setup ----------
+#
 include(Plugin.cmake)
 
 # -------- Setup completed, build the plugin --------
@@ -80,11 +82,6 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
 
   if (COMMAND add_plugin_libraries)
     add_plugin_libraries()
-  endif ()
-
-  if (EXISTS "libs/jsoncpp" AND NOT TARGET ocpn::jsoncpp)
-    add_subdirectory("libs/jsoncpp")
-    target_link_libraries(${PACKAGE_NAME} ocpn::jsoncpp)
   endif ()
 
 endif ()

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+3.1.0 TBD
+* Drop the special treatment of libjsoncpp. Plugins which depends
+  depends in this library must include and use it explicitly.
+* Use the script win\_deps.bat in both CI and "manual" builds.
+
+
 3.0.0 Nov 27, 2021
 
 * Update shipdriver main code to use correct config file section

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,65 +1,39 @@
+---
 clone_folder: c:\project\opencpn\plugin_src
 shallow_clone: false
 clone_depth: 10
 
 image:
-- Visual Studio 2017
+  - Visual Studio 2017
 
-platform: 
-# - x64
-- Win32
+platform:
+  - Win32
 
 configuration: RelWithDebInfo
-test: OFF
+test: false
 
 install:
-  # VS2015 and earlier version - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  
-  # set environment variables for wxWidgets
-  - set WXWIN=C:\wxWidgets-3.1.2
-  - set wxWidgets_ROOT_DIR=%WXWIN%
-  - set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
-  - cmd: SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
-
-  # install dependencies:
-  - choco install poedit
-
-  # Download and unzip wxwidgets
-  - ps: Start-FileDownload https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -FileName wxWidgets-3.1.2.7z
-  - cmd: 7z x wxWidgets-3.1.2.7z -o%WXWIN% > null
-
-  # some debugging information
-  # - cmake --help
-  # - set Displays sensitive password!
-
-  # build wxWidgets - Disabled as we provide prebuilt WX to save time
-  #- cmd: cd %WXWIN%\build\msw\
-  #- cmd: nmake -f makefile.vc BUILD=release SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
-  #- cmd: nmake -f makefile.vc BUILD=debug SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
+  - set VS_HOME=C:\Program Files (x86)\Microsoft Visual Studio\2017
+  - call "%VS_HOME%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 before_build:
-  # Unless removed, this interferes with the 32-bit python installation
+  # Ensure there is a working python installation. Unless removed,
+  # Python38-64 and Python27 interferes with the 32-bit 3.8 installation
   - rmdir /Q /S C:\Python38-x64
-
-  # python stuff required by upload.bat and git-push
+  - rmdir /Q /S C:\Python27
   - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
-  - py --version
-  - py -m ensurepip
-  - py -m pip install --upgrade pip
-  - pip install -q setuptools wheel
-  - pip install -q cloudsmith-cli
-  - pip install -q cryptography
 
 build_script:
-  - mkdir build
-  - cd build
-  - >
-    cmake -T v141_xp -G "Visual Studio 15 2017"
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo  ..
+  - call buildwin\win_deps.bat
+  - mkdir build && cd build
+  - cmake -T v141_xp -G "Visual Studio 15 2017" ..
+  - cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
   - cmake --build . --target tarball --config RelWithDebInfo
-  - py ..\ci\windows-ldd
-  - cmd: upload.bat
-  - py ..\ci\git-push
 
+after_build:
+  # Something in build_script messes with %PATH%:
+  - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
 
+  - python ..\ci\windows-ldd
+  - call upload.bat
+  - python ..\ci\git-push

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -6,7 +6,6 @@ rem Initial run will do choco installs requiring administrative
 rem privileges.
 rem
 
-
 python --version > nul 2>&1 && python -m ensurepip > nul 2>&1
 if errorlevel 1 (
    choco install -y python
@@ -30,7 +29,8 @@ set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
 SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%
 if not exist %WXWIN% (
   wget --version > nul 2>&1 || choco install -y wget
-  wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download -O wxWidgets-3.1.2.7z
+  wget --no-check-certificate -q -O wxWidgets-3.1.2.7z ^
+      https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download
   7z i > nul 2>&1 || choco install -y 7zip
   7z x wxWidgets-3.1.2.7z -o%WXWIN%
 )

--- a/cmake/PluginLibs.cmake
+++ b/cmake/PluginLibs.cmake
@@ -75,12 +75,5 @@ if (TARGET OpenGL::OpenGL OR TARGET OpenGL::GL)
 endif ()
 
 find_package(wxWidgets REQUIRED ${WX_COMPONENTS})
-if (MSYS)
-  # This is just a hack. I think the bug is in FindwxWidgets.cmake
-  string(
-    REGEX REPLACE "/usr/local" "\\\\;C:/MinGW/msys/1.0/usr/local"
-    wxWidgets_INCLUDE_DIRS ${wxWidgets_INCLUDE_DIRS}
-  )
-endif ()
 include(${wxWidgets_USE_FILE})
 target_link_libraries(${PACKAGE_NAME} ${wxWidgets_LIBRARIES})


### PR DESCRIPTION
 - Drop old, lingering MSYS patch in PluginLibs.cmake
 - Like in Debian builds, use the same script win_deps.bat in both CI and "manual" builds. Clean up appveyor.yml.
 - Drop the special handling of the jsoncpp library, the root cause behind #330, partially fixed in 3.0  branch