### PR TITLE
update-templates: Don't default to shipdriver/master (#366).

### DIFF
--- a/update-templates
+++ b/update-templates
@@ -11,12 +11,13 @@
 
 function usage() {
     cat << EOT
-Usage: update-templates [-T]  <treeish>
-       update-templates [-h | -l]
+Usage:
+    update-templates [-T]  <treeish>
+    update-templates [-h | -l]
+
 Parameters:
     treeish:
          A shipdriver tag or branch.
-
 Options:
     -l   List available shipdriver tags
     -h   Print this message and exit

--- a/update-templates
+++ b/update-templates
@@ -15,7 +15,7 @@ Usage: update-templates [-T]  <treeish>
        update-templates [-h | -l]
 Parameters:
     treeish:
-         A shipdriver tag, branch or commit.
+         A shipdriver tag or branch.
 
 Options:
     -l   List available shipdriver tags

--- a/update-templates
+++ b/update-templates
@@ -11,16 +11,22 @@
 
 function usage() {
     cat << EOT
-Usage: update-templates [-T]  [treeish]
+Usage: update-templates [-T]  <treeish>
        update-templates [-h | -l]
 Parameters:
     treeish:
-         A shipdriver tag, branch or commit, defaults to shipdriver/master
+         A shipdriver tag, branch or commit.
 
 Options:
-    -T   Test mode, do not auto-update
     -l   List available shipdriver tags
     -h   Print this message and exit
+    -T   Test mode, do not auto-update
+
+Examples:
+    update-templates -l                   -- List available tags
+    update-templates sd3.0.0              -- Update from sd3.0.0 tag
+    update-templates shipdriver/v3.0      -- Update from v3.0 release branch
+    update-templates shipdriver/master    -- Update from development branch
 EOT
 }
 
@@ -69,9 +75,14 @@ while getopts "tThl" opt; do
 done
 shift $((OPTIND-1))
 
-test -z "$test_mode" || set -x
-source_treeish=${1:-"shipdriver/master"}
+if [ -z "$1" ]; then
+    usage >&2
+    exit 1
+fi
 
+test -z "$test_mode" || set -x
+
+source_treeish=$1
 
 # Refuse to run unless the index is clean:
 clean=$(git status --porcelain)


### PR DESCRIPTION
Refuse to run without arguments. Enhance help message and make it
focus on using tags.

Closes: #366