### PR TITLE
V3.0: tentative v3.0.1-beta1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,19 +54,6 @@ jobs:
         default: "fp-arm20-v2"
     <<: *flatpak-steps
 
-  build-flatpak-x86-1808:
-    machine:
-      image: ubuntu-2004:202010-01
-    environment:
-      - OCPN_TARGET: flatpak
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
-      - BUILD_1808: "true"
-    parameters:
-      cache-key:
-        type: string
-        default: "fp-x86-18-v2"
-    <<: *flatpak-steps
-
   build-flatpak-x86-2008:
     machine:
       image: ubuntu-2004:202010-01
@@ -173,9 +160,6 @@ workflows:
     jobs:
 
       - build-flatpak-arm64:
-          <<: *std-filters
-
-      - build-flatpak-x86-1808:
           <<: *std-filters
 
       - build-flatpak-x86-2008:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+3.0.1-beta1 TBD
+* Actually use the tag as effective version (#349)
+* update-templates: Don't forget to update buildwin (#133).
+* update-templates: Remove unused files (#336).
+* update-templates: Only import sd\* tags to client plugin
+* ci: flatpak: Drop transition 18.08 builds
+* ci: flatpak: Build aarch 64 from master branch after 5.6.0 release.
+
 3.0.0 Nov 27, 2021
 
 * Update shipdriver main code to use correct config file section

--- a/UPDATE_TEMPLATES.md
+++ b/UPDATE_TEMPLATES.md
@@ -64,23 +64,35 @@ Running
 -------
 
 The script is run from the plugin top directory using
-`./update-templates`. In windows, assuming standard installation paths:
+`./update-templates`. In windows CMD, assuming standard installation paths:
 
     > "C:\Program Files\Git\bin\bash.exe" update-templates
 
 Usage summary:
 
-    update-templates [-T | -h] [treeish]
+    update-templates [-T] [treeish]
+    update-templates  -h
+    update-templates  -l
+    
+**treeish** defaults to _shipdriver/master_ i. e., templates are updated
+from shipdriver's development branch. It could be set to a branch
+like _shipdriver/v3.0_ or a tag like _sd3.0.0_ to retrieve data from
+corresponding git trees.
 
-The *treeish* argument can be used to merge changes from another shipdriver
-branch than the default shipdriver/master.
+**-l** lists available tags which can be used as _treeish_
 
-_-T_ runs in test mode, lots of output, requires an existing remote and
-does not self-update.
+**-T** runs in test mode, lots of output, requires an existing shipdriver 
+remote and does not self-update.
 
 *update-templates -h* prints the complete help message.
 
 Script unconditionally updates known files and commits them directly.
+
+Examples:
+
+    update-templates shipdriver/v3.0    -- get updates from v3.0 branch
+    update-templates sd3.0.0            -- get updates from sd3.0.0 tag
+    update-templates -l                 -- list all available tags
 
 Checking modifications in CMakeLists.txt and flatpak manifest
 -------------------------------------------------------------

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -50,7 +50,6 @@ flatpak remote-add --user --if-not-exists \
 # x86_64 only using last known 18.08 commit on stable branch.
 
 commit_1808=959f5fd700f72e63182eabb9821b6aa52fb12189eddf72ccf99889977b389447
-FLATPAK_BRANCH=stable
 if [ "$(uname -m)" = "aarch64" ]; then
     flatpak install --user -y --noninteractive \
         flathub org.freedesktop.Sdk//20.08
@@ -58,7 +57,6 @@ if [ "$(uname -m)" = "aarch64" ]; then
         https://flathub.org/beta-repo/flathub-beta.flatpakrepo
     flatpak install --user -y --or-update  --noninteractive \
         flathub-beta org.opencpn.OpenCPN
-    FLATPAK_BRANCH=beta
 elif [ -n "$BUILD_1808" ]; then
     flatpak install --user -y --noninteractive \
         flathub org.freedesktop.Sdk//18.08
@@ -77,7 +75,6 @@ fi
 # Patch the runtime version so it matches the nightly builds
 # or beta as appropriate.
 test -w flatpak/$MANIFEST || sudo chmod go+w flatpak/$MANIFEST
-sed -i "/^runtime-version/s/:.*/: $FLATPAK_BRANCH/" flatpak/$MANIFEST
 
 # The flatpak checksumming needs python3:
 if ! python3 --version 2>&1 >/dev/null; then

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -45,19 +45,12 @@ fi
 flatpak remote-add --user --if-not-exists \
     flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-# aarch64 is built from beta branch, regular x86_64 from stable.
+# aarch64 is built from beta branch, regular x86_64 from master.
 # Both uses 20.08. Compatibility 18.08 builds are built for
-# x86_64 only using last known 18.08 commit on stable branch.
+# x86_64 only using last known 18.08 commit on master branch.
 
 commit_1808=959f5fd700f72e63182eabb9821b6aa52fb12189eddf72ccf99889977b389447
-if [ "$(uname -m)" = "aarch64" ]; then
-    flatpak install --user -y --noninteractive \
-        flathub org.freedesktop.Sdk//20.08
-    flatpak remote-add --user --if-not-exists flathub-beta \
-        https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-    flatpak install --user -y --or-update  --noninteractive \
-        flathub-beta org.opencpn.OpenCPN
-elif [ -n "$BUILD_1808" ]; then
+if [ -n "$BUILD_1808" ]; then
     flatpak install --user -y --noninteractive \
         flathub org.freedesktop.Sdk//18.08
     flatpak install --user -y --or-update --noninteractive \

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -109,7 +109,11 @@ set(_pre_rel ${PKG_PRERELEASE})
 if (NOT "${_pre_rel}" STREQUAL "" AND _pre_rel MATCHES "^[^-]")
   string(PREPEND _pre_rel "-")
 endif ()
-set(pkg_semver "${PROJECT_VERSION}${_pre_rel}+${_build_id}.${_gitversion}")
+if ("${_git_tag}" STREQUAL "")
+  set(pkg_semver "${PROJECT_VERSION}${_pre_rel}+${_build_id}.${_gitversion}")
+else ()
+  set(pkg_semver "${_git_tag}")
+endif ()
 
 # pkg_displayname: GUI name
 if (ARCH MATCHES "arm64|aarch64")
@@ -128,12 +132,8 @@ string(APPEND pkg_displayname
 set(pkg_xmlname ${pkg_displayname})
 
 # pkg_tarname: Tarball basename
-if ("${_git_tag}" STREQUAL "")
-  set(pkg_tarname "${PLUGIN_API_NAME}-${pkg_semver}")
-else ()
-  set(pkg_tarname "${PLUGIN_API_NAME}-${_git_tag}")
-endif ()
-string(APPEND pkg_tarname
+string(CONCAT pkg_tarname
+  "${PLUGIN_API_NAME}-${pkg_semver}"
   "_${plugin_target}-${plugin_target_version}-${_pkg_arch}"
 )
 

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -32,7 +32,7 @@ execute_process(
 )
 
 execute_process(
-  COMMAND git tag --contains HEAD
+  COMMAND git tag --points-at HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE _git_tag
   RESULT_VARIABLE error_code

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -182,9 +182,17 @@ function (flatpak_target manifest)
   set(_fp_script "
     execute_process(
       COMMAND
-        flatpak-builder
-          --state-dir ${CMAKE_SOURCE_DIR}/flatpak/cache --force-clean
+        flatpak-builder --force-clean --keep-build-dirs
           ${CMAKE_CURRENT_BINARY_DIR}/app ${manifest}
+    )
+    # Copy the data out of the sandbox to installation directory
+    execute_process(
+      COMMAND
+        flatpak-builder  --run app ${manifest}  bash -c \"
+          stable_link=$(find /run/build -maxdepth 1 -type l)\; \
+          cp -ar $stable_link/app/files/*           \
+              ${CMAKE_CURRENT_BINARY_DIR}/app/files
+        \"
     )
     execute_process(
       COMMAND bash -c \"sed -e '/@checksum@/d' \

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -189,7 +189,7 @@ function (flatpak_target manifest)
     execute_process(
       COMMAND
         flatpak-builder  --run app ${manifest}  bash -c \"
-          stable_link=$(find /run/build -maxdepth 1 -type l)\; \
+          set -x\; stable_link=$(find /run/build -maxdepth 1 -type l)\; \
           cp -ar $stable_link/app/files/*           \
               ${CMAKE_CURRENT_BINARY_DIR}/app/files
         \"

--- a/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
@@ -7,7 +7,7 @@
 id: org.opencpn.OpenCPN.Plugin.shipdriver
 runtime: org.opencpn.OpenCPN
 runtime-version: stable
-#runtime-version: master   # for nightly builds
+#runtime-version: devel   # for nightly builds
 sdk: org.freedesktop.Sdk//20.08
 build-extension: true
 separate-locales: false

--- a/scripts/local-build.rc
+++ b/scripts/local-build.rc
@@ -2,18 +2,24 @@
 # CLOUDSMITH_API_KEY are secrets and hence obfuscated here. Other values
 # are as used by me.
 #
-# Modify as required and install in:
+# The configuration is used by the local-build, git-push and local-push
+# scripts. It is not required for a regular local build according to
+# INSTALL.md
+#
+# To be used, this template should be copied to it's installation path:
 #
 #    Linux:          ~/.config/local-build.rc
 #    Windows (cmd):  %APPDATA%\local-build.rc
 #    Windows (bash): $APPDATA/local-build.rc
 #
-# The variables here are the same as used when setting up a builder like
-# circleci or Appveyor. See:
+# Once in place, modify it according to your setup. The variables here are
+# the same as used when setting up a builder like CircleCI or Appveyor. See:
 # https://opencpn-manuals.github.io/main/AlternativeWorkflow/CircleCI.html#_set_the_environment_variables_for_appveyor
 #
+# NOTE: Don't commit secrets into the git repository by editing this file
+# in place before copying it.
 
-export CLOUDSMITH_API_KEY=39afdeadbeefxxerrnotevenhexdigitsher
+export CLOUDSMITH_API_KEY=MySecretApiKey
 export GIT_KEY_PASSWORD=MySecretPassword
 export GIT_REPO=git@github.com:leamas/plugins.git
 

--- a/update-templates
+++ b/update-templates
@@ -113,6 +113,10 @@ git checkout $source_treeish buildwin
 git add buildwin
 git commit -m "Templates: Updating buildwin"
 
+if [ -d libs ]; then git rm -rf libs/*; fi
+git checkout $source_treeish libs
+git add libs
+git commit -m "Templates: Updating libs"
 
 # If Plugin.cmake exists we should also update CMakeLists.txt
 if [ -f Plugin.cmake ]; then CMakeLists=CMakeLists.txt; fi

--- a/update-templates
+++ b/update-templates
@@ -81,23 +81,14 @@ if [ -z "$test_mode" ]; then
     git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
     git remote update shipdriver
 
-    # Create a new update branch and work on that
-    hash=$(git rev-parse --short  $source_treeish)
-    new_branch="update.$hash"
-    if git rev-parse $new_branch &> /dev/null; then git branch -D $new_branch; fi
-    git branch $new_branch $source_treeish
-    echo "Created temporary work branch  $new_branch"
-
     echo "Checking for updates of updates-templates script"
-    if [ -z "$test_mode" ]; then
-        if ! git diff --quiet HEAD $source_treeish -- update-templates; then
-            git checkout $source_treeish update-templates
-            cat << EOT
+    if ! git diff --quiet HEAD $source_treeish -- update-templates; then
+        git checkout $source_treeish update-templates
+        cat << EOT
 update-templates script is updated to latest version. Please commit
 changes and re-run script.
 EOT
-            exit 0
-        fi
+        exit 0
     fi
 fi
 
@@ -177,7 +168,7 @@ if [ -f cmake/TemplateVersion ]; then
         >> $our_manifest
     git rm -f $src_manifest
 fi
-    
+
 echo "Create or update cmake/TemplateVersion"
 echo "# Created by update-templates" > cmake/TemplateVersion
 echo "date: $(date -u +'%Y-%m-%d %H:%M UTC')" >> cmake/TemplateVersion

--- a/update-templates
+++ b/update-templates
@@ -35,7 +35,7 @@ function list_sd_tags() {
 if [[ -d /c && "$0" =~ .*update-templates ]]; then
     tmpfile=$(mktemp)
     cp $0 $tmpfile
-    exec $tmpfile
+    exec $tmpfile $@
 fi
 
 # Handle options and parameters

--- a/update-templates
+++ b/update-templates
@@ -89,23 +89,24 @@ EOT
 fi
 
 echo "Updating cmake/ and ci/"
-git rm -rf cmake/*
+if [ -d cmake ]; then git rm -rf cmake/*; fi
 git checkout $source_treeish cmake
 git add cmake
 git commit -m "Templates: Updating cmake"
 
-git rm -rf ci/*
+if [ -d ci ]; then  git rm -rf ci/*; fi
 git checkout $source_treeish ci
 git add ci
 git commit -m "Templates: Updating ci"
 
-git rm -rf scripts/*
+if [ -d scripts ]; then git rm -rf scripts/*; fi
 git checkout $source_treeish scripts
 git add scripts
 git commit -m "Templates: Updating scripts"
 
 
-
+# If Plugin.cmake exists we should also update CMakeLists.txt
+if [ -f Plugin.cmake ]; then CMakeLists=CMakeLists.txt; fi
 
 echo "Templates: Updating other files"
 for f in \
@@ -120,7 +121,8 @@ for f in \
     plugin.xml.in \
     .travis.yml \
     update-templates \
-    UPDATE_TEMPLATES.md
+    UPDATE_TEMPLATES.md \
+    $CMakeLists
 do
     if test -d $f; then git rm -rf $f; fi
     git checkout $source_treeish $f
@@ -135,6 +137,15 @@ if [ -e update-ignored ]; then
         git checkout HEAD $f
     done
 fi
+
+for f in buildosx buildwin/NSIS* libs/AndroidLibs.cmake mingw; do
+    if test -e $f; then git rm -rf $f; fi
+done
+git diff-index --quiet --cached HEAD -- || {
+    echo "Removing unused files"
+    git commit -am "Templates: Removing obsoleted and unused files."
+}
+
 
 if [ -f cmake/TemplateVersion ]; then
     our_manifest=$(echo flatpak/org.opencpn.OpenCPN.Plugin.*.yaml)

--- a/update-templates
+++ b/update-templates
@@ -66,11 +66,6 @@ if [ -n "$clean" ]; then
     exit 1
 fi
 
-# Fetch all available shipdriver sd* tags
-for t in $(list_sd_tags); do
-    git fetch -q shipdriver refs/tags/$t:refs/tags/$t --no-tags
-done
-
 if [ -z "$test_mode" ]; then
     # Set up the shipdriver remote
     if git ls-remote --exit-code shipdriver &>/dev/null; then
@@ -80,6 +75,11 @@ if [ -z "$test_mode" ]; then
     echo "Adding new shipdriver remote"
     git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
     git remote update shipdriver
+
+    # Fetch all available shipdriver sd* tags
+    for t in $(list_sd_tags); do
+        git fetch -q shipdriver refs/tags/$t:refs/tags/$t --no-tags
+    done
 
     echo "Checking for updates of updates-templates script"
     if ! git diff --quiet HEAD $source_treeish -- update-templates; then

--- a/update-templates
+++ b/update-templates
@@ -88,7 +88,7 @@ EOT
     fi
 fi
 
-echo "Updating cmake/ and ci/"
+echo "Updating cmake/, scripts/, buildwin/ and ci/"
 if [ -d cmake ]; then git rm -rf cmake/*; fi
 git checkout $source_treeish cmake
 git add cmake
@@ -103,6 +103,11 @@ if [ -d scripts ]; then git rm -rf scripts/*; fi
 git checkout $source_treeish scripts
 git add scripts
 git commit -m "Templates: Updating scripts"
+
+if [ -d buildwin ]; then git rm -rf buildwin/*; fi
+git checkout $source_treeish buildwin
+git add buildwin
+git commit -m "Templates: Updating buildwin"
 
 
 # If Plugin.cmake exists we should also update CMakeLists.txt

--- a/update-templates
+++ b/update-templates
@@ -11,12 +11,13 @@
 
 function usage() {
     cat << EOT
-Usage: update-templates [-T]  <treeish>
-       update-templates [-h | -l]
+Usage:
+    update-templates [-T]  <treeish>
+    update-templates [-h | -l]
+
 Parameters:
     treeish:
          A shipdriver tag or branch.
-
 Options:
     -l   List available shipdriver tags
     -h   Print this message and exit

--- a/update-templates
+++ b/update-templates
@@ -164,7 +164,6 @@ if [ -f cmake/TemplateVersion ]; then
     our_manifest=$(echo flatpak/org.opencpn.OpenCPN.Plugin.*.yaml)
     echo "Append shipdriver flatpak manifest's log of changes to $our_manifest"
 
-    git fetch --tags ${source_treeish%/*}
     prev_commit=$(sed -n '/commit:/s/.*: *//p' cmake/TemplateVersion)
     src_manifest=flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
     git checkout $source_treeish $src_manifest

--- a/update-templates
+++ b/update-templates
@@ -15,7 +15,7 @@ Usage: update-templates [-T]  <treeish>
        update-templates [-h | -l]
 Parameters:
     treeish:
-         A shipdriver tag, branch or commit.
+         A shipdriver tag or branch.
 
 Options:
     -l   List available shipdriver tags

--- a/update-templates
+++ b/update-templates
@@ -11,16 +11,23 @@
 
 function usage() {
     cat << EOT
-Usage: update-templates [-t] [-T] [-h] [treeish]
-
+Usage: update-templates [-T]  [treeish]
+       update-templates [-h | -l]
 Parameters:
     treeish:
          A shipdriver tag, branch or commit, defaults to shipdriver/master
 
 Options:
     -T   Test mode, do not auto-update
+    -l   List available shipdriver tags
     -h   Print this message and exit
 EOT
+}
+
+function list_sd_tags() {
+    # List all tags in shipdriver remote with a 'sd' prefix
+    git ls-remote --tags shipdriver \
+        | sed  -n -e '/{}/d' -e 's|.*tags/||' -e '/^sd/p'
 }
 
 # Exec on tmpfile to avoid file lock when updating script on Windows.
@@ -34,11 +41,13 @@ fi
 # Handle options and parameters
 usage="Usage: $0 [-t] [-T] [treeish]"
 merge_opt=""
-while getopts "tTh" opt; do
+while getopts "tThl" opt; do
     case "${opt}" in
         T)  test_mode=true
             ;;
         h)  usage; exit 0
+            ;;
+        l)  list_sd_tags; exit 0
             ;;
         *)  usage >&2; exit 1
             ;;
@@ -57,6 +66,11 @@ if [ -n "$clean" ]; then
     exit 1
 fi
 
+# Fetch all available shipdriver sd* tags
+for t in $(list_sd_tags); do
+    git fetch -q shipdriver refs/tags/$t:refs/tags/$t --no-tags
+done
+
 if [ -z "$test_mode" ]; then
     # Set up the shipdriver remote
     if git ls-remote --exit-code shipdriver &>/dev/null; then
@@ -66,7 +80,6 @@ if [ -z "$test_mode" ]; then
     echo "Adding new shipdriver remote"
     git remote add shipdriver https://github.com/Rasbats/shipdriver_pi.git
     git remote update shipdriver
-    git fetch --tags shipdriver
 
     # Create a new update branch and work on that
     hash=$(git rev-parse --short  $source_treeish)

--- a/update-templates
+++ b/update-templates
@@ -11,16 +11,22 @@
 
 function usage() {
     cat << EOT
-Usage: update-templates [-T]  [treeish]
+Usage: update-templates [-T]  <treeish>
        update-templates [-h | -l]
 Parameters:
     treeish:
-         A shipdriver tag, branch or commit, defaults to shipdriver/master
+         A shipdriver tag, branch or commit.
 
 Options:
-    -T   Test mode, do not auto-update
     -l   List available shipdriver tags
     -h   Print this message and exit
+    -T   Test mode, do not auto-update
+
+Examples:
+    update-templates -l                   -- List available tags
+    update-templates sd3.0.0              -- Update from sd3.0.0 tag
+    update-templates shipdriver/v3.0      -- Update from v3.0 release branch
+    update-templates shipdriver/master    -- Update from development branch
 EOT
 }
 
@@ -55,9 +61,14 @@ while getopts "tThl" opt; do
 done
 shift $((OPTIND-1))
 
-test -z "$test_mode" || set -x
-source_treeish=${1:-"shipdriver/master"}
+if [ -z "$1" ]; then
+    usage >&2
+    exit 1
+fi
 
+test -z "$test_mode" || set -x
+
+source_treeish=$1
 
 # Refuse to run unless the index is clean:
 clean=$(git status --porcelain)


### PR DESCRIPTION
Cherry-picked fixes from master:
  - Actually use tag as version (#349).
  - update-templates is basically brought to same state as master, besides opencpn-libs submodule. Lot's of fixes.
  - Flatpak ci changes updated to master, they reflects the OpenCPN 5.6.0 release.
  - Some documentation fixes.

Hopefully, this should not break any eggs while actually fixing some bugs. If OK with you I suggest that we tag this as v3.0.1-beta1 and then makes some further testing