### PR TITLE
ci: flatpak, raspbian: Fix (sort of) typo (#383)

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -65,7 +65,7 @@ make -j $(nproc) VERBOSE=1 flatpak
 
 # Restore permissions and owner in build tree.
 if [ -d /ci-source ]; then sudo chown --reference=/ci-source -R . ../cache; fi
-sudo chmod --reference=.. .
+sudo chown --reference=.. .
 
 # Install cloudsmith and cryptography, required by upload script and git-push
 python3 -m pip install -q --user --upgrade pip

--- a/ci/generic-build-raspbian-armhf.sh
+++ b/ci/generic-build-raspbian-armhf.sh
@@ -47,7 +47,7 @@ rm -rf build-raspbian; mkdir build-raspbian; cd build-raspbian
 cmake -DCMAKE_BUILD_TYPE=debug ..
 make -j $(nproc) VERBOSE=1 tarball
 ldd  app/*/lib/opencpn/*.so
-sudo chmod --reference=.. .
+sudo chown --reference=.. .
 EOF
 
 


### PR DESCRIPTION
As heading says: fix sort  of typo errors in the ci scripts.

I think this should fix the issues in #383. However, cloudsmith is currently down and all builds fail in the upload phase.  

The cloudsmith status is available in https://status.cloudsmith.io/.  I have been in contact with their support which basically says we have to wait until the incident reported for January is resolved before things start top work again.