### PR TITLE
Drop xenial builds (#399).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,15 +81,6 @@ jobs:
       - run: cd build-osx; /bin/bash < upload.sh
       - run: ci/git-push.sh  build-osx
 
-  build-xenial:
-    docker:
-      - image: circleci/buildpack-deps:xenial-scm
-    environment:
-      - OCPN_TARGET: xenial
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
-      - USE_DEADSNAKES_PY37: 1
-    <<: *debian-steps
-
   build-bionic:
     docker:
       - image: cimg/base:stable-18.04
@@ -166,9 +157,6 @@ workflows:
           <<: *std-filters
 
       - build-macos:
-          <<: *std-filters
-
-      - build-xenial:
           <<: *std-filters
 
       - build-bionic-gtk3:

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -30,16 +30,6 @@ exec > >(tee $builddir/build.log) 2>&1;
 sudo apt -qq update || apt update
 sudo apt-get -qq install devscripts equivs software-properties-common
 
-if [ -n  "$USE_DEADSNAKES_PY37" ]; then
-    sudo add-apt-repository -y ppa:deadsnakes/ppa
-    sudo apt -qq update
-    sudo  apt-get -q install  python3.7
-    for py in $(ls /usr/bin/python3.[0-9]); do
-        sudo update-alternatives --install /usr/bin/python3 python3 $py 1
-    done
-    sudo update-alternatives --set python3 /usr/bin/python3.7
-fi
-
 sudo mk-build-deps -ir build-deps/control
 sudo apt-get -q --allow-unauthenticated install -f
 


### PR DESCRIPTION
Since they don't work, remove them for now. 

This is possibly  not the last word on #399, but considering all the new build stuff in the pipe we probably just don't have the manpower to also maintain outdated, unsupported xenial any more. 