### PR TITLE
win_deps.bat: Make PATH handling more consistent.

### DIFF
--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -1,19 +1,39 @@
-rem
-rem Install build dependencies. Requires a working choco installation,
-rem see https://docs.chocolatey.org/en-us/choco/setup.
-rem
-rem Initial run will do choco installs requiring administrative
-rem privileges.
-rem
+::
+:: Install build dependencies. Requires a working choco installation,
+:: see https://docs.chocolatey.org/en-us/choco/setup.
+::
+:: Initial run will do choco installs requiring administrative
+:: privileges.
+::
 
+:: Install the pathman tool: https://github.com/therootcompany/pathman
+:: Fix PATH so it can be used in this script
+::
+if not exist "%HomeDrive%%HomePath%\.local\bin\pathman.exe" (
+    pushd "%HomeDrive%%HomePath%"
+    curl.exe -sA "MS" https://webinstall.dev/pathman | powershell
+    popd
+)
+pathman list > nul 2>&1
+if errorlevel 1 set PATH=%PATH%;%HomeDrive%\%HomePath%\.local\bin
+pathman add %HomeDrive%%HomePath%\.local\bin >nul
+
+:: Install choco cmake and add it's persistent user path element
+::
+set CMAKE_HOME=C:\Program Files\CMake
+if not exist "%CMAKE_HOME%\bin\cmake.exe" choco install -y cmake
+pathman add "%CMAKE_HOME%\bin" > nul
+
+:: Install choco poedit and add it's persistent user path element
+::
+set POEDIT_HOME=C:\Program Files (x86)\Poedit\Gettexttools
+if not exist "%POEDIT_HOME%" choco install -y poedit
+pathman add "%POEDIT_HOME%\bin" > nul
+
+:: Update required python stuff
+::
 python --version > nul 2>&1 && python -m ensurepip > nul 2>&1
-if errorlevel 1 (
-   choco install -y python
-)
-cmake --version > nul 2>&1
-if errorlevel 1 (
-   choco install -y cmake
-)
+if errorlevel 1 choco install -y python
 python --version
 python -m ensurepip
 python -m pip install --upgrade pip
@@ -21,24 +41,20 @@ python -m pip install -q setuptools wheel
 python -m pip install -q cloudsmith-cli
 python -m pip install -q cryptography
 
+:: Install pre-compiled wxWidgets and other DLL; add required paths.
+::
 set SCRIPTDIR=%~dp0
 set WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.1.2
-
 set wxWidgets_ROOT_DIR=%WXWIN%
 set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
-SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%
-if not exist %WXWIN% (
+if not exist "%WXWIN%" (
   wget --version > nul 2>&1 || choco install -y wget
-  wget --no-check-certificate -q -O wxWidgets-3.1.2.7z ^
-      https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download
+  wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download ^
+      -O wxWidgets-3.1.2.7z
   7z i > nul 2>&1 || choco install -y 7zip
   7z x wxWidgets-3.1.2.7z -o%WXWIN%
 )
-
-if not exist "C:\Program Files (x86)\Poedit" (
-  choco install -y  poedit
-)
-SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin
-SET PATH=%PATH%;C:\Program Files (x86)\Poedit
+pathman add "%WXWIN%" > nul
+pathman add "%wxWidgets_LIB_DIR%" > nul
 
 refreshenv


### PR DESCRIPTION
Use the pathman tool to set PATH in the registry rather than the
current session. Besides that the PATH set now is persistent
pathman also ensures that path elements are not duplicated.

There seems to be some changes in how Windows handles PATH
lately, not sure. The fixes are hopefully sound anyway.