### PR TITLE
Win build fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,13 @@ To build an android armhf tarball
 #### Building on windows (MSVC)
 On windows, a different workflow is used:
 
+    > ..\minimal-path.bat
     > ..\buildwin\win_deps.bat
     > cmake -T v141_xp -G "Visual Studio 15 2017" ^
            -DCMAKE_BUILD_TYPE=RelWithDebInfo  ..
     > cmake --build . --target tarball --config RelWithDebInfo
+
+The _minimal-path.bat_ file strips down %PATH% to a very small path, excluding
+most if not all otherwise available tools. In many cases this neither required
+nor convenient and can be excluded. However, using it represents a tested
+baseline.

--- a/buildwin/minimal-path.bat
+++ b/buildwin/minimal-path.bat
@@ -1,0 +1,7 @@
+:: Set a minimal PATH which is tested with win_deps.bat. 
+::
+set PATH1=C:\ProgramData\chocolatey\bin
+set PATH2=C:\Windows\system32
+set PATH3=C:\Windows
+
+set PATH=%PATH1%;%PATH2%;%PATH3%

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -68,7 +68,7 @@ set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
 if not exist "%WXWIN%" (
   wget --version > nul 2>&1 || choco install -y wget
   wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download ^
-      -O wxWidgets-3.1.2.7z
+      --no-check-certificate -O wxWidgets-3.1.2.7z
   7z i > nul 2>&1 || choco install -y 7zip
   7z x wxWidgets-3.1.2.7z -o%WXWIN%
 )

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -7,7 +7,7 @@
 ::
 
 :: Install the pathman tool: https://github.com/therootcompany/pathman
-:: Fix Path to so it can be used in this script
+:: Fix PATH so it can be used in this script
 ::
 if not exist "%HomeDrive%%HomePath%\.local\bin\pathman.exe" (
     pushd "%HomeDrive%%HomePath%"

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -7,7 +7,7 @@
 ::
 
 :: Install the pathman tool: https://github.com/therootcompany/pathman
-:: Fix PATH so it can be used in this script
+:: Fix Path to so it can be used in this script
 ::
 if not exist "%HomeDrive%%HomePath%\.local\bin\pathman.exe" (
     pushd "%HomeDrive%%HomePath%"
@@ -21,19 +21,37 @@ pathman add %HomeDrive%%HomePath%\.local\bin >nul
 :: Install choco cmake and add it's persistent user path element
 ::
 set CMAKE_HOME=C:\Program Files\CMake
-if not exist "%CMAKE_HOME%\bin\cmake.exe" choco install -y cmake
-pathman add "%CMAKE_HOME%\bin" > nul
+cmake --version > nul 2>&1
+if errorlevel 1 (
+    if not exist "%CMAKE_HOME%\bin\cmake.exe" choco install -y cmake
+    pathman add "%CMAKE_HOME%\bin" > nul
+)
 
 :: Install choco poedit and add it's persistent user path element
 ::
 set POEDIT_HOME=C:\Program Files (x86)\Poedit\Gettexttools
-if not exist "%POEDIT_HOME%" choco install -y poedit
-pathman add "%POEDIT_HOME%\bin" > nul
+msgmerge --version > nul 2>&1
+if errorlevel 1 (
+    if not exist "%POEDIT_HOME%" choco install -y poedit
+    pathman add "%POEDIT_HOME%\bin" > nul
+)
+
+:: Install choco git and add it's persistent user path elementA
+::
+set GIT_HOME=C:\Program Files\Git
+git --version > nul 2>&1
+if errorlevel 1 (
+   if not exist "%GIT_HOME%\cmd\git.exe" choco install -y git
+   pathman add %GIT_HOME%\cmd > nul
+)
 
 :: Update required python stuff
 ::
 set PYTHON_HOME=C:\Python310
-if not exist "%PYTHON_HOME%" choco install python
+python --version > nul 2>&1
+if errorlevel 1 (
+    if not exist "%PYTHON_HOME%\python.exe" choco install -y python
+)
 python --version
 python -m ensurepip
 python -m pip install --upgrade pip
@@ -41,7 +59,7 @@ python -m pip install -q setuptools wheel
 python -m pip install -q cloudsmith-cli
 python -m pip install -q cryptography
 
-:: Install pre-compiled wxWidgets and other DLL; add required paths.
+:: Install pre-compiled wxWidgets and other DLL and add required paths
 ::
 set SCRIPTDIR=%~dp0
 set WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.1.2

--- a/cmake/AndroidLibs.cmake
+++ b/cmake/AndroidLibs.cmake
@@ -36,7 +36,7 @@ if (NOT EXISTS ${OCPN_ANDROID_CACHEDIR}/master.zip)
       https://github.com/bdbcat/OCPNAndroidCommon/archive/master.zip
       ${OCPN_ANDROID_CACHEDIR}/master.zip
     EXPECTED_HASH
-      SHA256=ac36afaf4f026e9b2624a963f5356f5b1fb2c45dec1134209333a8b46fb05ca0
+      SHA256=0f07975c17d62671cae91fe0770126d73625476018ce205e87c689ba2dc89d70
     SHOW_PROGRESS
   )
 endif ()


### PR DESCRIPTION
Create a tested build baseline on Windows which does not depend on user's %PATH%.

New file _minimal-path.bat_ and updates to _INSTALL.md_

EDIT: And a totally unrelated fix to the Android builds -- Dave ha updated the library blob and the hash needs to be updated