### PR TITLE
ci: Add a Debian Bullseye build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,14 @@ jobs:
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
+  build-bullseye:
+    docker:
+      - image: circleci/buildpack-deps:bullseye-scm
+    environment:
+      - OCPN_TARGET: buster
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    <<: *debian-steps
+
   build-android-arm64:
     docker:
       - image: circleci/android:api-28-ndk
@@ -215,6 +223,9 @@ workflows:
           <<: *std-filters
 
       - build-buster:
+          <<: *std-filters
+
+      - build-bullseye:
           <<: *std-filters
 
       - build-android-arm64:


### PR DESCRIPTION
Add a Debian 11/Bullseye build. That it is missing seems to be some sort of oversight, it is required when handling the "Debian plugins everywhere" roadmap.

We'll get a  *lot* of builds until 5.6.2 is release in March at which point we can start dropping unneeded builds.