### PR TITLE
win_deps.bat: Make PATH handling more consistent (v 3.0 update).

### DIFF
--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -21,37 +21,19 @@ pathman add %HomeDrive%%HomePath%\.local\bin >nul
 :: Install choco cmake and add it's persistent user path element
 ::
 set CMAKE_HOME=C:\Program Files\CMake
-cmake --version > nul 2>&1
-if errorlevel 1 (
-    if not exist "%CMAKE_HOME%\bin\cmake.exe" choco install -y cmake
-    pathman add "%CMAKE_HOME%\bin" > nul
-)
+if not exist "%CMAKE_HOME%\bin\cmake.exe" choco install -y cmake
+pathman add "%CMAKE_HOME%\bin" > nul
 
 :: Install choco poedit and add it's persistent user path element
 ::
 set POEDIT_HOME=C:\Program Files (x86)\Poedit\Gettexttools
-msgmerge --version > nul 2>&1
-if errorlevel 1 (
-    if not exist "%POEDIT_HOME%" choco install -y poedit
-    pathman add "%POEDIT_HOME%\bin" > nul
-)
-
-:: Install choco git and add it's persistent user path elementA
-::
-set GIT_HOME=C:\Program Files\Git
-git --version > nul 2>&1
-if errorlevel 1 (
-   if not exist "%GIT_HOME%\cmd\git.exe" choco install -y git
-   pathman add %GIT_HOME%\cmd > nul
-)
+if not exist "%POEDIT_HOME%" choco install -y poedit
+pathman add "%POEDIT_HOME%\bin" > nul
 
 :: Update required python stuff
 ::
-set PYTHON_HOME=C:\Python310
-python --version > nul 2>&1
-if errorlevel 1 (
-    if not exist "%PYTHON_HOME%\python.exe" choco install -y python
-)
+python --version > nul 2>&1 && python -m ensurepip > nul 2>&1
+if errorlevel 1 choco install -y python
 python --version
 python -m ensurepip
 python -m pip install --upgrade pip
@@ -59,7 +41,7 @@ python -m pip install -q setuptools wheel
 python -m pip install -q cloudsmith-cli
 python -m pip install -q cryptography
 
-:: Install pre-compiled wxWidgets and other DLL and add required paths
+:: Install pre-compiled wxWidgets and other DLL; add required paths.
 ::
 set SCRIPTDIR=%~dp0
 set WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.1.2
@@ -68,7 +50,7 @@ set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
 if not exist "%WXWIN%" (
   wget --version > nul 2>&1 || choco install -y wget
   wget https://download.opencpn.org/s/E2p4nLDzeqx4SdX/download ^
-      --no-check-certificate -O wxWidgets-3.1.2.7z
+      -O wxWidgets-3.1.2.7z
   7z i > nul 2>&1 || choco install -y 7zip
   7z x wxWidgets-3.1.2.7z -o%WXWIN%
 )


### PR DESCRIPTION
Use the pathman tool to set PATH in the registry rather than the
current session. Besides that the PATH set now is persistent
pathman also ensures that path elements are not duplicated.

There seems to be some changes in how Windows handles PATH
lately, not sure. The fixes are hopefully sound anyway.