### PR TITLE
Changelog: Prepare 3.1.0-beta1 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
-3.1.0 TBD
+3.1.0-beta1 TBD
 * The drone.io builder is not longer used (#217).
 * The Xenial builds are removed (#399)
-* Raspbian armhf builds are replaced with Ubunut (#380).
+* Raspbian armhf builds are replaced with Ubuntu (#380).
 * The Flatpak runtime 18.08 compatibility builds are removed.
 * New Debian 10/11 builds are added (#381).
 * Add a git submodule with libraries. This affects how the plugin

--- a/update-templates
+++ b/update-templates
@@ -140,13 +140,6 @@ for dir in cmake ci scripts buildwin; do
     update_dir $dir $source_treeish
 done
 
-echo "Updating libs"
-git checkout $source_treeish libs
-git add libs
-git diff-index --quiet --cached HEAD -- || {
-    git commit -m "Templates: Updating libs"
-}
-
 # If Plugin.cmake exists we should also update CMakeLists.txt
 if [ -f Plugin.cmake ]; then CMakeLists=CMakeLists.txt; fi
 
@@ -184,7 +177,7 @@ git diff-index --quiet --cached HEAD -- || {
 
 
 # Check for files/dirs which are private, but should be copied on first run.
-for f in config.h.in build-deps; do
+for f in config.h.in build-deps libs; do
     if test -e $f; then continue; fi
     git checkout $source_treeish $f
 done


### PR DESCRIPTION
The new OpenCPN release 5.5.2 is looming, ETA is  "March". Before that we need to have at least the new builds in master branch available.

All relevant issues are closed. IMHO, it's time to start testing 3.1.0 by merging this PR, updating the date in the changelog  and tag it as sd3.1.0-beta1.

Thoughts?