### PR TITLE
Builds: Handle updated ubuntu repo key, drop obsolete ubuntu-wx315 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,19 +112,6 @@ jobs:
         default: "fp-x86-20-v2"
     <<: *flatpak-steps
 
-  build-flatpak-x86-wx315:
-    machine:
-      image: ubuntu-2004:202010-01
-    environment:
-      - OCPN_TARGET: flatpak
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
-      - BUILD_WX31: true
-    steps:
-      - checkout
-      - run: ci/circleci-build-flatpak.sh
-      - run: cd /build-flatpak; /bin/bash < upload.sh
-      - run: ci/git-push.sh /build-flatpak
-
   build-macos:
     macos:
       xcode: "12.5.1"
@@ -232,9 +219,6 @@ workflows:
           <<: *std-filters
 
       - build-flatpak-x86-2008:
-          <<: *std-filters
-
-      - build-flatpak-x86-wx315:
           <<: *std-filters
 
       - build-macos:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+3.1.1 TBD
+* Handle updated ubuntu repository keys (#436).
+* Remove too early ubuntu-wx315 which fails in validation (#437).
+
 3.1.0 Mar 18, 2022
 
 3.1.0-beta2 Mar 16, 2022

--- a/ci/circleci-build-ubuntu-armhf.sh
+++ b/ci/circleci-build-ubuntu-armhf.sh
@@ -29,9 +29,11 @@ cat > $ci_source/build.sh << "EOF"
 # The  docker images are updated and have installed devscripts and equivs
 # i. e., what is required for mk-build-deps.
 
-sudo apt -q update
-sudo mk-build-deps  /ci-source/build-deps/control
-sudo apt -y install ./opencpn-build-deps_1.0_all.deb
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6AF7F09730B3F0A4
+export DEBIAN_FRONTEND=noninteractive
+apt -q update
+mk-build-deps  /ci-source/build-deps/control
+apt -y install ./opencpn-build-deps_1.0_all.deb
 sudo apt-get -q --allow-unauthenticated install -f
 
 # cmake 3.20/3.22 is installed in the docker images before uploading to


### PR DESCRIPTION
The  ubuntu-wx31 build is ahead of the development at opencpn/plugins and should be dropped for now.

Handle updated ubuntu repos by adding the proper key to the keyring to make sure the update runs correctly.

Closes: #437 

Unless more issues are pending, please tag  as sd3.1.1 after merging.
EDIT: As usual, please update Changelog.md before tagging.