### PR TITLE
opencpn-libs: Clean up compiler warnings.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+3.2.0 TBD 
+* Placeholder for 3.2 changes.
+
 3.1.1 Mar 27, 2022
 * Handle updated ubuntu repository keys (#436).
 * Remove too early ubuntu-wx315 which fails in validation (#437).

--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -32,7 +32,7 @@ set(OCPN_RELEASE_REPO
 # -------  Plugin setup --------
 #
 set(PKG_NAME ShipDriver_pi)
-set(PKG_VERSION  3.1.0)
+set(PKG_VERSION  3.2.0)
 set(PKG_PRERELEASE "")  # Empty, or a tag like 'beta'
 
 set(DISPLAY_NAME ShipDriver)    # Dialogs, installer artifacts, ...


### PR DESCRIPTION
Update opencpn-libs -- changes for disabling useless warnings. LIbraries now builds cleanly.

Initiate branch top be about upcoming 3.2.0 (Plugin.cmake, Changelog).