### PR TITLE
update-templates: Remove unused drone.yml  (#380, #217)

### DIFF
--- a/update-templates
+++ b/update-templates
@@ -195,7 +195,7 @@ if [ -e update-ignored ]; then
     done
 fi
 
-for f in buildosx buildwin/NSIS* libs/AndroidLibs.cmake mingw; do
+for f in buildosx buildwin/NSIS* libs/AndroidLibs.cmake mingw .drone.yml; do
     if test -e $f; then git rm -rf $f; fi
 done
 git diff-index --quiet --cached HEAD -- || {


### PR DESCRIPTION
As heading says: let update-templates remove unused .drone.yml to avoid build errors.