### PR TITLE
V3.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 3.1.2 TBD
-* Placeholder
+* AndroidLibs: Update downloaded library hash (#446).
 
 3.1.1 Mar 27, 2022
 * Handle updated ubuntu repository keys (#436).

--- a/cmake/AndroidLibs.cmake
+++ b/cmake/AndroidLibs.cmake
@@ -36,7 +36,7 @@ if (NOT EXISTS ${OCPN_ANDROID_CACHEDIR}/master.zip)
       https://github.com/bdbcat/OCPNAndroidCommon/archive/master.zip
       ${OCPN_ANDROID_CACHEDIR}/master.zip
     EXPECTED_HASH
-      SHA256=ac36afaf4f026e9b2624a963f5356f5b1fb2c45dec1134209333a8b46fb05ca0
+      SHA256=a15ebd49fd4e7c0f2d6e99328ed6a9fdb8ed7c8fcaa993cab585fc9d8aab4f56
     SHOW_PROGRESS
   )
 endif ()

--- a/update-templates
+++ b/update-templates
@@ -153,7 +153,6 @@ for f in \
     .drone.yml \
     .gitattributes \
     .gitignore \
-    flatpak/manifest.wx31.patch \
     INSTALL.md \
     plugin.xml.in \
     .travis.yml \


### PR DESCRIPTION
Urgent update -- all Android builds are broken (#446). 

After merging, please update Changelog.md and tag this build as sd3.1.2

--a