### PR TITLE
Flatpak: Update to build against wxWindows 3.2  (#458)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,7 @@ installer available from OpenCPN 5.2.0 is built using:
 To build the flatpak tarball:
 
     $ cmake ..
+    $ git config --global protocol.file.allow always
     $ make flatpak
 
 Historically, it has been possible to build legacy packages like

--- a/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
@@ -1,8 +1,8 @@
 #
 # Branches and runtimes:
-#   - master     Nigthly builds, 20.08 runtime
-#   - beta       Flathub beta branch, aarch64 with 20.08 runtime.
-#   - stable     Flathub main branch, x86_64 with 20.08 runtime.
+#   - master     Nigthly builds, 22.08 runtime
+#   - beta       Flathub beta branch with 22.08 runtime.
+#   - stable     Flathub main branch x86_64 with 20.08 runtime.
 #
 # This is a template used to create a complete manifest in the build
 # directory. Doing so, it handles three tokens:

--- a/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
@@ -1,5 +1,5 @@
 #
-# Branches and runtimes:
+# Branches and runtime-version:
 #   - master     Nigthly builds, 22.08 runtime
 #   - beta       Flathub beta branch with 22.08 runtime.
 #   - stable     Flathub main branch x86_64 with 20.08 runtime.
@@ -17,9 +17,9 @@
 # See cmake/ConfigureManifest.cmake for details.
 #
 id: org.opencpn.OpenCPN.Plugin.@plugin_name
+
 runtime: org.opencpn.OpenCPN
-runtime-version: stable
-#runtime-version: devel   # for nightly builds
+runtime-version: beta   # FIXME(alec) Revert to stable when updated to 22.08
 sdk: org.freedesktop.Sdk//22.08
 build-extension: true
 separate-locales: false


### PR DESCRIPTION
The major taks here is that a alpha version of OpenCPN now is available in the flathub beta branch. Update manifest to use the beta branch and thus build against wx32 as planned 

EDIT: Due to new git behaviour  plugging a security hole there are updated instructions how to build  flatpak. See INSTALL.md.