### PR TITLE
Flatpak wx32: Clean up build scripts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,10 +133,11 @@ jobs:
     parameters:
       cache-key:
         type: string
+        # Update the last part, here v2, to invalidate cache
         default: "fp-arm20-v2"
     <<: *flatpak-steps
 
-  build-flatpak-x86-2008:
+  build-flatpak-x86:
     machine:
       image: ubuntu-2004:202010-01
     environment:
@@ -145,6 +146,7 @@ jobs:
     parameters:
       cache-key:
         type: string
+        # Update the last part, here v2, to invalidate cache
         default: "fp-x86-20-v2"
     <<: *flatpak-steps
 
@@ -202,7 +204,7 @@ workflows:
       - build-flatpak-arm64:
           <<: *std-filters
 
-      - build-flatpak-x86-2008:
+      - build-flatpak-x86:
           <<: *std-filters
 
       - build-macos:

--- a/update-templates
+++ b/update-templates
@@ -176,8 +176,10 @@ git diff-index --quiet --cached HEAD -- || {
 }
 
 # Update flatpak runtime version as required:
-sed -i '/sdk: org.freedesktop.Sdk/s/20.08/22.08' \
-   flatpak/org.opencpn.OpenCPN.Plugin.*.yaml
+sed -i \
+    -e '/sdk: org.freedesktop.Sdk/s/20.08/22.08/' \
+    -e '/^runtime-version:/s/:.*/: beta/' \
+  flatpak/org.opencpn.OpenCPN.Plugin.*.yaml
 git add flatpak
 git diff-index --quiet --cached HEAD -- || {
     echo "Updating Updating flatpak runtime version to 22.08"


### PR DESCRIPTION
**Note:** After applying these changes we don't build any more plugins for O56. This should basically be OK, but we need to leave the existing O56 plugins in the catalog rather than replacing them with the O58 ones.

During the beta period until O58 is release we will have to build flatpak plugins against the flathub beta branch, this is the only one which is linked against wx-32. Also, this is of course the closest we can get to upcoming O58.

The build manifest needs to be updated with correct runtime-version (22.08) and runtime branch (beta). For local builds, this is done by update-templates.

For the CI builds the manifest is patched by the build script, so it does not need to be updated. In other words, it should work out of the box for existing plugins, updated or not.