### PR TITLE
Debian: Add wx32 (wxWidgets 3.2) builds for bullseye (OpenCPN#2797).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,22 @@ jobs:
       - run: cd build-debian; /bin/bash < upload.sh
       - run: ci/git-push.sh build-debian
 
+  build-bullseye-wx32-arm64:
+    machine:
+      image: ubuntu-2004:2022.04.1
+    resource_class: arm.medium
+    environment:
+      - OCPN_TARGET: bullseye
+      - BUILD_WX32: true
+      - TARGET_TUPLE: debian-wx32;11;arm64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    steps:
+      - checkout
+      - run: ci/circleci-build-debian-docker.sh
+      - run: cd build-debian; /bin/bash < upload.sh
+      - run: ci/git-push.sh build-debian
+
+
   build-bookworm:
     machine:
       image: ubuntu-2004:2022.04.1
@@ -226,10 +242,13 @@ workflows:
       - build-android-armhf:
           <<: *std-filters
 
-      - build-bullseye:
+      - build-bullseye-wx32:
           <<: *std-filters
 
-      - build-bullseye-wx32:
+      - build-bullseye-wx32-arm64:
+          <<: *std-filters
+
+      - build-bullseye:
           <<: *std-filters
 
       - build-bullseye-armhf:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,22 @@ jobs:
       - run: cd build-debian; /bin/bash < upload.sh
       - run: ci/git-push.sh build-debian
 
+  build-bullseye-wx32-armhf:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      - TARGET_TUPLE: debian;11;armhf
+      - OCPN_TARGET: bullseye
+      - BUILD_WX32: true
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    steps:
+      - checkout
+      - run: ci/circleci-build-debian-armhf.sh
+      - run: cd build-debian; /bin/bash < upload.sh
+      - run: ci/git-push.sh build-debian
+
+
   build-bullseye-arm64:
     machine:
       image: ubuntu-2004:2022.04.1
@@ -224,6 +240,9 @@ workflows:
           <<: *std-filters
 
       - build-bullseye-wx32-arm64:
+          <<: *std-filters
+
+      - build-bullseye-wx32-armhf:
           <<: *std-filters
 
       - build-bullseye:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,16 @@ jobs:
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
+  build-bullseye-wx32:
+    docker:
+      - image: circleci/buildpack-deps:bullseye-scm
+    environment:
+      - OCPN_TARGET: bullseye
+      - BUILD_WX32: true
+      - TARGET_TUPLE: debian-wx32;11;x86_64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    <<: *debian-steps
+
   build-bullseye-armhf:
     machine:
       image: ubuntu-2004:202101-01
@@ -217,6 +227,9 @@ workflows:
           <<: *std-filters
 
       - build-bullseye:
+          <<: *std-filters
+
+      - build-bullseye-wx32:
           <<: *std-filters
 
       - build-bullseye-armhf:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,28 +23,6 @@ flatpak-steps: &flatpak-steps
     - run: ci/git-push.sh /build-flatpak
 
 jobs:
-  build-buster:
-    docker:
-      - image: circleci/buildpack-deps:buster-scm
-    environment:
-      - OCPN_TARGET: buster
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
-    <<: *debian-steps
-
-  build-buster-armhf:
-    machine:
-      image: ubuntu-2004:202101-01
-    resource_class: arm.medium
-    environment:
-      - TARGET_TUPLE: debian;10;armhf
-      - OCPN_TARGET: buster
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
-    steps:
-      - checkout
-      - run: ci/circleci-build-debian-armhf.sh
-      - run: cd build-debian; /bin/bash < upload.sh
-      - run: ci/git-push.sh build-debian
-
   build-bullseye:
     docker:
       - image: circleci/buildpack-deps:bullseye-scm
@@ -255,12 +233,6 @@ workflows:
           <<: *std-filters
 
       - build-bullseye-arm64:
-          <<: *std-filters
-
-      - build-buster-armhf:
-          <<: *std-filters
-
-      - build-buster:
           <<: *std-filters
 
       - build-bookworm-arm64:

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -25,6 +25,46 @@ cd $ci_source
 git submodule update --init opencpn-libs
 
 cat > $ci_source/build.sh << "EOF"
+function remove_wx30() {
+  apt remove -y \
+      libwxsvg3 \
+      wx3.0-i18n \
+      wx-common \
+      libwxgtk3.0-gtk3-0v5 \
+      libwxbase3.0-0v5 \
+      libwxsvg3 wx3.0-i18n \
+      wx-common \
+      libwxgtk3.0-gtk3-0v5 \
+      libwxbase3.0-0v5 wx3.0-headers \
+      libwxsvg3 \
+      libwxsvg-dev
+}
+
+# Install generated packages
+function install_wx32() {
+  test -d /usr/local/pkg || mkdir /usr/local/pkg
+  chmod a+w /usr/local/pkg
+  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets"
+  head="deb/debian/pool/bullseye/main"
+  vers="3.2.1+dfsg-1~bpo11+1"
+  pushd /usr/local/pkg
+  wget  $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
+  wget  $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
+  wget  $repo/$head/w/wx/wx-common_3.2.1+dfsg-1/wx-common_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxgtk-webview3.2-dev_3.2.1+dfsg-1/libwxgtk-webview3.2-dev_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxgtk-webview3.2-0_3.2.1+dfsg-1/libwxgtk-webview3.2-0_3.2.1+dfsg-1_arm64.deb 
+  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1/libwxgtk-media3.2-dev_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxgtk3.2-dev_3.2.1+dfsg-1/libwxgtk3.2-dev_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxgtk3.2-0_3.2.1+dfsg-1/libwxgtk3.2-0_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxbase3.2-0_3.2.1+dfsg-1/libwxbase3.2-0_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1/libwxgtk-media3.2-dev_3.2.1+dfsg-1_arm64.deb
+  wget  $repo/$head/l/li/libwxsvg-dev_2:1.5.23+dfsg-1~bpo11+1/libwxsvg-dev_1.5.23+dfsg-1~bpo11+1_arm64.deb
+  wget  $repo/$head/l/li/libwxsvg3_2:1.5.23+dfsg-1~bpo11+1/libwxsvg3_1.5.23+dfsg-1~bpo11+1_arm64.deb
+  dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
+  sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
+      /usr/lib/*-linux-gnu/wx/config/gtk3-unicode-3.2
+  popd
+}
 
 set -x
 
@@ -46,20 +86,26 @@ else
 fi
 
 if [ -n "@BUILD_WX32@" ]; then
-  exit 1
+  remove_wx30  
+  install_wx32
 fi
-
 
 cd /ci-source
 rm -rf build-debian; mkdir build-debian; cd build-debian
-cmake -DCMAKE_BUILD_TYPE=Release -DOCPN_TARGET_TUPLE="@TARGET_TUPLE@" ..
+cmake -DCMAKE_BUILD_TYPE=Release\
+   -DOCPN_TARGET_TUPLE="@TARGET_TUPLE@" \
+    ..
+
 make -j $(nproc) VERBOSE=1 tarball
 ldd  app/*/lib/opencpn/*.so
 chown --reference=.. .
 EOF
 
+if [ -n "$BUILD_WX32" ]; then OCPN_WX_ABI_OPT="-DOCPN_WX_ABI=wx32"; fi
+
 sed -i "s/@TARGET_TUPLE@/$TARGET_TUPLE/" $ci_source/build.sh
 sed -i "s/@BUILD_WX32@/$BUILD_WX32/" $ci_source/build.sh
+#sed -i "s/@OCPN_WX_ABI_OPT@/$OCPN_WX_ABI_OPT/" $ci_source/build.sh
 
 
 # Run script in docker image

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -45,6 +45,10 @@ else
     apt-get install -y cmake
 fi
 
+if [ -n "@BUILD_WX32@" ]; then
+  exit 1
+fi
+
 
 cd /ci-source
 rm -rf build-debian; mkdir build-debian; cd build-debian
@@ -55,6 +59,7 @@ chown --reference=.. .
 EOF
 
 sed -i "s/@TARGET_TUPLE@/$TARGET_TUPLE/" $ci_source/build.sh
+sed -i "s/@BUILD_WX32@/$BUILD_WX32/" $ci_source/build.sh
 
 
 # Run script in docker image

--- a/ci/download-wx32.sh
+++ b/ci/download-wx32.sh
@@ -1,0 +1,95 @@
+#  Create a wxWidgets 3.2 backport to bullseye in /usr/local/pkg
+#
+
+# single backport patch to bookworm source
+function create_patch() {
+cat << EOF >patch1.patch
+diff --git a/debian/changelog b/debian/changelog
+index 9835d62..a58fc47 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,3 +1,10 @@
++wxwidgets3.2 (${vers}) bullseye-backports; urgency=medium
++
++  * local package
++  * Rebuild for bullseye-backports.
++
++ -- Alec Leamas <leamas.alec@gmail.com>  Sat, 19 Nov 2022 13:07:44 +0100
++
+ wxwidgets3.2 (3.2.1+dfsg-1) unstable; urgency=medium
+
+   * Update to new upstream release 3.2.1
+--
+2.30.2
+EOF
+}
+
+
+# Remove existing wx30 packages
+function remove_wx30() {
+  sudo apt remove \
+      libwxsvg3 \
+      wx3.0-i18n \
+      wx-common \
+      libwxgtk3.0-gtk3-0v5 \
+      libwxbase3.0-0v5 \
+      libwxsvg3 wx3.0-i18n \
+      wx-common \
+      libwxgtk3.0-gtk3-0v5 \
+      libwxbase3.0-0v5 wx3.0-headers
+}
+
+# Install generated packages
+function install_wx32() {
+  test -d /usr/local/pkg || mkdir /usr/local/pkg
+  sudo chmod a+w /usr/local/pkg
+  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets"
+  head="deb/debian/pool/bullseye/main"
+  vers="3.2.1+dfsg-1~bpo11+1"
+  pushd /usr/local/pkg
+  wget $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_amd64.deb
+  wget $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
+  wget $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
+  wget $repo/$head/l/li/libwxgtk-webview3.2-dev_${vers}/libwxgtk-webview3.2-dev_${vers}_amd64.deb
+  wget $repo/$head/l/li/libwxgtk-webview3.2-0_${vers}/libwxgtk-webview3.2-0_${vers}_amd64.deb
+  wget $repo/$head/l/li/libwxgtk-media3.2-dev_${vers}/libwxgtk-media3.2-dev_${vers}_amd64.deb
+  wget $repo/$head/l/li/libwxgtk3.2-dev_${vers}/libwxgtk3.2-dev_${vers}_amd64.deb
+  wget $repo/$head/l/li/libwxgtk3.2-0_${vers}/libwxgtk3.2-0_${vers}_amd64.deb
+  wget $repo/$head/l/li/libwxbase3.2-0_${vers}/libwxbase3.2-0_${vers}_amd64.deb
+  sudo apt install -y $(ls /usr/local/pkg/*deb)
+  popd
+}
+
+if [ -d /usr/local/pkg ]; then
+  echo "wxWidgets32 packages already in place"
+else
+  set -x
+  echo "Cloning wxWidgets sources"
+  mkdir wxWidgets; cd wxWidgets
+  create_patch;
+  git clone https://gitlab.com/leamas/wxwidgets3.2.git
+  cd wxwidgets3.2
+  git fetch origin master:master
+  git fetch origin pristine-tar:pristine-tar
+  
+  echo "Creating the .orig tarball"
+  git checkout pristine-tar
+  pristine-tar checkout $(pristine-tar list | tail -1)
+  mv *xz ..
+  rm *
+  
+  echo "Patch and building package"
+  git checkout master
+  patch -p1 < ../patch1.patch
+  git checkout .; git clean -fxd
+  mk-build-deps --root-cmd=sudo -i -r
+  rm *changes *buildinfo
+  debuild -us -uc
+  
+  echo "Installing pkg in /usr/local/pkg"
+  test -d /usr/local/pkg || sudo mkdir /usr/local/pkg
+  sudo cp ../*deb /usr/local/pkg
+  sudo rm /usr/local/pkg/*dbgsym* 
+  cd ../...
+fi
+


### PR DESCRIPTION
According to discussion in https://github.com/OpenCPN/OpenCPN/discussions/2797 we need to add three builds for Debian 11/Bullseye which are linked against wxWidgets 3.2 -- this makes the plugins work for O58 on Focal and Bullseye.

WxWidgets3.2 and the the wxsvg library are backported and rebuilt  for all three platforms and are available at https://cloudsmith.io/~alec-leamas/repos/wxwidgets/. 

The builds here downloads these libraries and builds using them. It's an awful hack, but it's a one time shot: from Bookworm/Debian 12/Ubuntu 24.04  the proper libraries will be available in Debian/Ubuntu repos.