### PR TITLE
ci: windows: Update to VS 2022, use bundled python 3.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ shallow_clone: false
 clone_depth: 10
 
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
 
 platform:
   - Win32
@@ -13,29 +13,21 @@ configuration: RelWithDebInfo
 test: false
 
 install:
-  - set VS_HOME=C:\Program Files (x86)\Microsoft Visual Studio\2019
+  - set VS_HOME=C:\Program Files\Microsoft Visual Studio\2022
   - call "%VS_HOME%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 before_build:
-  # Ensure there is a working python installation. Unless removed,
-  # Python38-64 and Python27 interferes with the 32-bit 3.8 installation
-  - rmdir /Q /S C:\Python38-x64
-  - rmdir /Q /S C:\Python27
-  - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
-  # And check out submodules:
   - git submodule update --init opencpn-libs
 
 build_script:
   - call buildwin\win_deps.bat
   - mkdir build && cd build
-  - cmake -A Win32 -G "Visual Studio 16 2019" ..
+  - cmake -A Win32 -G "Visual Studio 17 2022" ..
+  - cmake -DCMAKE_GENERATOR_PLATFORM=Win32 ..
   - cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
   - cmake --build . --target tarball --config RelWithDebInfo
 
 after_build:
-  # Something in build_script messes with %PATH%:
-  - cmd: SET PATH=C:\Python38;C:\Python38\Scripts;%PATH%
-
   - python ..\ci\windows-ldd
   - call upload.bat
   - python ..\ci\git-push

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -11,7 +11,10 @@
 ::
 if not exist "%HomeDrive%%HomePath%\.local\bin\pathman.exe" (
     pushd "%HomeDrive%%HomePath%"
-    curl.exe -sA "MS" https://webinstall.dev/pathman | powershell
+    curl.exe -sA "windows/10 x86"  -o webi-pwsh-install.ps1 ^
+        https://webi.ms/packages/_webi/webi-pwsh.ps1 
+    powershell.exe -ExecutionPolicy Bypass -File webi-pwsh-install.ps1
+    webi pathman 
     popd
 )
 pathman list > nul 2>&1
@@ -49,8 +52,8 @@ set wxWidgets_ROOT_DIR=%WXWIN%
 set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
 if not exist "%WXWIN%" (
   wget --version > nul 2>&1 || choco install -y wget
-  wget https://download.opencpn.org/s/mKn7bczRPSJXBtF/download ^
-      -O wxWidgets-3.2.1.7z
+  wget --no-verbose  -O wxWidgets-3.2.1.7z ^
+      https://download.opencpn.org/s/mKn7bczRPSJXBtF/download
   7z i > nul 2>&1 || choco install -y 7zip
   7z x wxWidgets-3.2.1.7z -o%WXWIN%
 )

--- a/ci/windows-ldd
+++ b/ci/windows-ldd
@@ -5,7 +5,7 @@
 import subprocess
 import glob
 dumpbin = glob.glob(
-  "C:/Program Files (x86)/*Visual Studio/2019/Community/VC/Tools/MSVC/*/bin/Hostx64/x64")[0]
+  "C:/Program Files/*Visual Studio/2022/Community/VC/Tools/MSVC/*/bin/Hostx64/x64")[0]
 dumpbin += "/dumpbin"
 lib = glob.glob("C:/project/opencpn/*/build/app/*/plugins/*.dll")[0]
 subprocess.run([dumpbin, "/dependents", lib])


### PR DESCRIPTION
- Update to Visual Studio 17 2022
- Use the provided python, no need to use choco to get a recent version
- Fix broken pathman installation