### PR TITLE
ci: debian: Add patch for matrix.h (wxwidgets#22790).

### DIFF
--- a/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
+++ b/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
@@ -1,0 +1,59 @@
+From 03eca5af92d4a395efc65dd8a6e936e33293f5b8 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Mon, 21 Nov 2022 14:20:15 +0100
+Subject: [PATCH] matrix.h: Patch attributes handling (wxwidgets#22790).
+
+---
+ defs.h   | 21 +++++++++++++++++++++
+ matrix.h |  3 ++-
+ 2 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/defs.h b/defs.h
+index e048cb7..d491939 100644
+--- a/defs.h
++++ b/defs.h
+@@ -169,6 +169,27 @@
+ #else /* !g++ */
+ #   define wxSUPPRESS_GCC_PRIVATE_DTOR_WARNING(name)
+ #endif
++/*
++    Some gcc versions choke on __has_cpp_attribute(gnu::visibility) due to the
++    presence of the colon, but we only need this macro in C++ code, so just
++    don't define it when using C.
++ */
++
++#ifdef __cplusplus
++
++/*
++    Special macro used for the classes that are exported and deprecated.
++    It exists because standard [[deprecated]] attribute can't be combined with
++    legacy __attribute__((visibility)), but we can't use [[visibility]] instead
++    of the latter because it can't be use in the same place in the declarations
++    where we use WXDLLIMPEXP_CORE. So we define this special macro which uses
++    the standard visibility attribute just where we can't do otherwise.
++
++    Heavily simplified for wxWidgets and gcc -- Alec Leamas
++ */
++    #define wxDEPRECATED_EXPORT_CORE(msg) \
++	__attribute__((visibility("default")))
++#endif
+ 
+ /*
+    Clang Support
+diff --git a/matrix.h b/matrix.h
+index d18a0d2..a3392b5 100644
+--- a/matrix.h
++++ b/matrix.h
+@@ -41,7 +41,8 @@ class
+ #ifndef WXBUILDING
+ wxDEPRECATED_MSG("use wxAffineMatrix2D instead")
+ #endif
+-WXDLLIMPEXP_CORE wxTransformMatrix: public wxObject
++wxDEPRECATED_EXPORT_CORE("use wxAffineMatrix2D instead")
++wxTransformMatrix: public wxObject
+ {
+ public:
+     wxTransformMatrix();
+-- 
+2.30.2
+

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -64,6 +64,11 @@ function install_wx32() {
   dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
   sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/*-linux-*/wx/config/gtk3-unicode-3.2
+
+  # See wxWidgets#22790. FIXME (leamas) To be removed after wxw 3.2.3
+  cd /usr/include/wx-3.2/wx/
+  patch -p1 < /ci-source/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
+
   popd
 }
 
@@ -93,6 +98,7 @@ if [ -n "@BUILD_WX32@" ]; then
   remove_wx30
   install_wx32
 fi
+
 
 cd /ci-source
 rm -rf build-debian; mkdir build-debian; cd build-debian

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -63,6 +63,10 @@ function install_wx32() {
   dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
   sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/*-linux-gnu/wx/config/gtk3-unicode-3.2
+
+  # See wxWidgets#22790. FIXME (leamas) To be removed after wxw 3.2.3
+  cd /usr/include/wx-3.2/wx/
+  patch -p1 < /ci-source/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
   popd
 }
 
@@ -89,6 +93,7 @@ if [ -n "@BUILD_WX32@" ]; then
   remove_wx30  
   install_wx32
 fi
+
 
 cd /ci-source
 rm -rf build-debian; mkdir build-debian; cd build-debian

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -52,10 +52,15 @@ function install_wx32() {
   sudo apt --fix-broken install
   sudo sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/$(uname -m)-linux-gnu/wx/config/gtk3-unicode-3.2
+  # See wxWidgets#22790. To be removed after wxw 3.2.3
+  cd /usr/include/wx-3.2/wx/
+  sudo patch -p1 \
+    < $here/../build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
   popd
 }
 
 set -xe
+here=$(cd $(dirname $0); pwd -P)
 
 # Load local environment if it exists i. e., this is a local build
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi


### PR DESCRIPTION
Apply a patch for the specific use case  in matrix .h which we use. This is supposed to become fixed in wxWidgets 3.2.3, but needs to be patched utnil then.

See: https://github.com/wxWidgets/wxWidgets/issues/22790