### PR TITLE
CMakeLists: Use a different project name when using wx32.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ include(Plugin.cmake)
 
 # -------- Setup completed, build the plugin --------
 #
+if ("${OCPN_TARGET_TUPLE}" MATCHES wx32)
+  # Evil, dirty hack to force a different name for wx32 builds. We
+  # need a cleaner solution here. FIXME(leamas)
+  set(PKG_NAME "${PKG_NAME}-wx32")
+endif ()
 project(${PKG_NAME} VERSION ${PKG_VERSION})
 include(PluginCompiler)
 


### PR DESCRIPTION
As heading says. This is a temporary  quick fix which even if it works should be replaced with something cleaner.