### PR TITLE
CI: Add configurable Buster builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,8 +205,7 @@ jobs:
     steps:
       - checkout
       - run: ci/circleci-build-android.sh
-      - run: sh -c "cd /build-$OCPN_TARGET; /bin/bash < upload.sh"
-      - run: sh -c "ci/git-push.sh /build-$OCPN_TARGET"
+      - run: ci/maybe-push-upload.sh
 
   build-android-armhf:
     docker:
@@ -217,8 +216,7 @@ jobs:
     steps:
       - checkout
       - run: ci/circleci-build-android.sh
-      - run: sh -c "cd /build-$OCPN_TARGET; /bin/bash < upload.sh"
-      - run: sh -c "ci/git-push.sh /build-$OCPN_TARGET"
+      - run: ci/maybe-push-upload.sh
 
 std-filters: &std-filters
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,17 @@ jobs:
       - run: ci/circleci-build-buster.sh
       - run: sh -c "ci/maybe-push-upload.sh"
 
+  build-buster-armhf:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    steps:
+      - checkout
+      - run: ci/circleci-build-buster-armhf.sh
+      - run: ci/maybe-push-upload.sh
+
   build-bullseye:
     docker:
       - image: circleci/buildpack-deps:bullseye-scm
@@ -273,4 +284,7 @@ workflows:
           <<: *std-filters
 
       - build-buster:
+          <<: *std-filters
+
+      - build-buster-armhf:
           <<: *std-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ flatpak-steps: &flatpak-steps
     - run: ci/git-push.sh /build-flatpak
 
 jobs:
+  build-buster:
+    docker:
+      - image: circleci/buildpack-deps:bullseye-scm
+    environment:
+      - OCPN_TARGET: bullseye
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+    steps:
+      - checkout
+      - run: ci/circleci-build-buster.sh
+      - run: sh -c "ci/maybe-push-upload.sh"
+
   build-bullseye:
     docker:
       - image: circleci/buildpack-deps:bullseye-scm
@@ -261,4 +272,7 @@ workflows:
           <<: *std-filters
 
       - build-bookworm:
+          <<: *std-filters
+
+      - build-buster:
           <<: *std-filters

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 build-*
+!build-conf.rc
 !build-deps
 po/*.pot
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ include(Plugin.cmake)
 
 # -------- Setup completed, build the plugin --------
 #
+if ("${OCPN_TARGET_TUPLE}" MATCHES wx32)
+  # Evil, dirty hack to force a different name for wx32 builds. We
+  # need a cleaner solution here. FIXME(leamas)
+  set(PKG_NAME "${PKG_NAME}-wx32")
+endif ()
 project(${PKG_NAME} VERSION ${PKG_VERSION})
 include(PluginCompiler)
 

--- a/build-conf.rc
+++ b/build-conf.rc
@@ -1,0 +1,14 @@
+#  How often oldstable is built. 
+#    0: never
+#    1: always
+#    other numbers: For example 10 means every tenth build.
+oldstable_build_rate=10
+
+#  Should oldstable build be uploaded to cloudsmith? <true|false>
+oldstable_upload="true"
+
+# Should oldstable builds be pushed to catalog clone? <true|false>
+oldstable_git_push="true"
+
+# Should android builds be disabled?  <true|false>
+android_disable="false"

--- a/build-conf.rc
+++ b/build-conf.rc
@@ -5,10 +5,12 @@
 oldstable_build_rate=10
 
 #  Should oldstable build be uploaded to cloudsmith? <true|false>
-oldstable_upload="true"
+oldstable_upload="false"
 
 # Should oldstable builds be pushed to catalog clone? <true|false>
-oldstable_git_push="true"
+oldstable_git_push="false"
 
-# Should android builds be disabled?  <true|false>
-android_disable="false"
+# Same as for oldstable above.
+android_build_rate=1
+android_upload="true"
+android_git_push="true"

--- a/ci/circleci-build-android.sh
+++ b/ci/circleci-build-android.sh
@@ -13,11 +13,13 @@
 
 set -xe
 
-uname -m
-# Read configuration end exit if android is disabled
+# Read configuration and check if we should really build this
 here=$(cd $(dirname $0); pwd -P)
 source $here/../build-conf.rc
-if [ "$android_disable" = "true" ]; then exit 0; fi
+if [ "$android_build_rate" -eq 0 ]; then exit 0; fi
+if [ $((CIRCLE_BUILD_NUM % android_build_rate)) -ne 0 ]; then
+    exit 0
+fi
 
 # Load local environment if it exists i. e., this is a local build
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi

--- a/ci/circleci-build-android.sh
+++ b/ci/circleci-build-android.sh
@@ -14,6 +14,10 @@
 set -xe
 
 uname -m
+# Read configuration end exit if android is disabled
+here=$(cd $(dirname $0); pwd -P)
+source $here/../build-conf.rc
+if [ "$android_disable" = "true" ]; then exit 0; fi
 
 # Load local environment if it exists i. e., this is a local build
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
@@ -45,7 +49,7 @@ sudo apt remove python3-six python3-colorama python3-urllib3
 export LC_ALL=C.UTF-8  LANG=C.UTF-8
 python3 -m pip install --user -q cloudsmith-cli cryptography
 
-# Building using NDK requries a recent cmake, the packaged is too old
+# Building using NDK requires a recent cmake, the packaged is too old
 python3 -m pip install --user -q cmake
 
 # Build tarball

--- a/ci/circleci-build-buster-armhf.sh
+++ b/ci/circleci-build-buster-armhf.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Build for Debian armhf in a docker container
+#
+# Copyright (c) 2021 Alec Leamas
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+set -xe
+
+# Read configuration and check if we should really build this
+here=$(cd $(dirname $0); pwd -P)
+source $here/../build-conf.rc
+if [ "$oldstable_build_rate" -eq 0 ]; then exit 0; fi
+if [ $((CIRCLE_BUILD_NUM % oldstable_build_rate)) -ne 0 ]; then
+    exit 0
+fi
+
+# Create build script
+#
+if [ -n "$TRAVIS_BUILD_DIR" ]; then
+    ci_source="$TRAVIS_BUILD_DIR"
+elif [ -d ~/project ]; then
+    ci_source=~/project
+else
+    ci_source="$(pwd)"
+fi
+
+cd $ci_source
+git submodule update --init opencpn-libs
+
+cat > $ci_source/build.sh << "EOF"
+
+set -x
+
+apt -y update
+apt -y install devscripts equivs wget git lsb-release
+
+mk-build-deps /ci-source/build-deps/control
+apt install -q -y ./opencpn-build-deps*deb
+apt-get -q --allow-unauthenticated install -f
+
+url='https://dl.cloudsmith.io/public/alec-leamas/opencpn-plugins-stable'
+wget --no-verbose \
+    $url/deb/debian/pool/buster/main/c/cm/cmake-data_3.19.3-0.1_all.deb
+wget --no-verbose \
+    $url/deb/debian/pool/buster/main/c/cm/cmake_3.19.3-0.1_armhf.deb
+apt install -y ./cmake_3.19.3-0.1_armhf.deb ./cmake-data_3.19.3-0.1_all.deb
+
+cd /ci-source
+rm -rf build-debian; mkdir build-debian; cd build-debian
+cmake -DCMAKE_BUILD_TYPE=Release -DOCPN_TARGET_TUPLE="debian;10;armhf" ..
+make -j $(nproc) VERBOSE=1 tarball
+ldd  app/*/lib/opencpn/*.so
+chown --reference=.. .
+EOF
+
+
+# Run script in docker image
+#
+if [ -n "$CI" ]; then
+    sudo apt -q update
+    sudo apt install qemu-user-static
+fi
+docker run --rm --privileged multiarch/qemu-user-static:register --reset || :
+docker run --platform linux/arm/v7 --privileged \
+    -e "CLOUDSMITH_STABLE_REPO=$CLOUDSMITH_STABLE_REPO" \
+    -e "CLOUDSMITH_BETA_REPO=$OCPN_BETA_REPO" \
+    -e "CLOUDSMITH_UNSTABLE_REPO=$CLOUDSMITH_UNSTABLE_REPO" \
+    -e "CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM" \
+    -e "TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER" \
+    -v "$ci_source:/ci-source:rw" \
+    -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static \
+    arm32v7/debian:buster /bin/bash -xe /ci-source/build.sh
+rm -f $ci_source/build.sh
+
+
+# Install cloudsmith-cli (for upload) and cryptography (for git-push).
+#
+if pyenv versions &>/dev/null;  then
+    pyenv versions | tr -d '*' | awk '{print $1}' | tail -1 \
+        > $HOME/.python-version
+fi
+python3 -m pip install -q --user cloudsmith-cli cryptography
+
+# python install scripts in ~/.local/bin, teach upload.sh to use in it's PATH:
+echo 'export PATH=$PATH:$HOME/.local/bin' >> ~/.uploadrc

--- a/ci/circleci-build-buster.sh
+++ b/ci/circleci-build-buster.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+# Build the Debian artifacts
+#
+
+# Copyright (c) 2021 Alec Leamas
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+set -xe
+
+# Read configuration and check if we should really build this
+here=$(cd $(dirname $0); pwd -P)
+source $here/../build-conf.rc
+if [ "$oldstable_build_rate" -eq 0 ]; then exit 0; fi
+if [ $((CIRCLE_BUILD_NUM % oldstable_build_rate)) -ne 0 ]; then
+    exit 0
+fi
+
+# Load local environment if it exists i. e., this is a local build
+if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
+if [ -d /ci-source ]; then cd /ci-source; fi
+
+git submodule update --init opencpn-libs
+
+# Set up build directory and possibly a visible link in /
+builddir=build-buster
+test -d $builddir || sudo mkdir $builddir  && sudo rm -rf $builddir/*
+sudo chmod 777 $builddir
+if [ -w "/" ]; then    # Running as root i. e., a docker build
+    if [ "$PWD" != "/" ]; then sudo ln -sf $PWD/$builddir /$builddir; fi
+fi
+
+# Create a log file.
+exec > >(tee $builddir/build.log) 2>&1;
+
+sudo apt -qq update || apt update
+sudo apt-get -qq install devscripts equivs software-properties-common
+
+mk-build-deps --root-cmd=sudo -ir build-deps/control
+rm -f *changes  *buildinfo
+
+sudo apt install -q \
+    python3-pip python3-setuptools python3-dev python3-wheel \
+    build-essential libssl-dev libffi-dev
+
+python3 -m pip install --user --upgrade -q setuptools wheel pip
+python3 -m pip install --user -q cloudsmith-cli cryptography cmake
+
+cd $builddir
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+make VERBOSE=1 tarball
+ldd app/*/lib/opencpn/*.so
+
+if [ -d /ci-source ]; then
+    sudo chown --reference=/ci-source -R . ../cache || :
+fi
+sudo chmod --reference=.. .

--- a/ci/maybe-push-upload.sh
+++ b/ci/maybe-push-upload.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Read build.conf.sh and conditionally run upload and git_push scripts.
+
+here=$(cd $(dirname $0); pwd -P)
+source $here/../build-conf.rc
+
+if [ ! -d /build-$OCPN_TARGET ]; then exit 0; fi   # no build available
+
+if [ "$oldstable_upload" = "true" ]; then
+    sh -c "cd /build-$OCPN_TARGET; /bin/bash < upload.sh"
+fi
+if [ "$oldstable_git_push" = "true" ]; then
+    sh -c "ci/git-push.sh /build-$OCPN_TARGET"
+fi

--- a/ci/maybe-push-upload.sh
+++ b/ci/maybe-push-upload.sh
@@ -1,15 +1,31 @@
 #!/bin/bash
 #
-# Read build.conf.sh and conditionally run upload and git_push scripts.
+# Read build-conf.sh and conditionally run upload and git_push scripts.
 
 here=$(cd $(dirname $0); pwd -P)
 source $here/../build-conf.rc
 
 if [ ! -d /build-$OCPN_TARGET ]; then exit 0; fi   # no build available
 
-if [ "$oldstable_upload" = "true" ]; then
+case ${OCPN_TARGET,} in
+  *buster*)
+      upload="$oldstable_upload"
+      git_push="$oldstable_git_push"
+      ;;
+
+  *android*)
+      upload="$android_upload"
+      git_push="$android_git_push"
+      ;;
+
+  *)  upload="true"
+      git_push="true"
+      ;;
+esac
+
+if [ "$upload" = "true" ]; then
     sh -c "cd /build-$OCPN_TARGET; /bin/bash < upload.sh"
 fi
-if [ "$oldstable_git_push" = "true" ]; then
+if [ "$git_push" = "true" ]; then
     sh -c "ci/git-push.sh /build-$OCPN_TARGET"
 fi

--- a/update-templates
+++ b/update-templates
@@ -186,10 +186,8 @@ git diff-index --quiet --cached HEAD -- || {
     git commit -m "opencpn-libs: Update to latest version."
 }
 
-
-
 # Check for files/dirs which are private, but should be copied on first run.
-for f in config.h.in build-deps libs; do
+for f in config.h.in build-deps build-conf.sh libs; do
     if test -e $f; then continue; fi
     git checkout $source_treeish $f
 done


### PR DESCRIPTION
After discussions with @bdbcat, add two new builds for buster-x86_64 and buster-armhf.

The basic position on Buster builds is that  the catalog is frozen, and that new builds not goes into the catalog. However, in rare cases there might be a need to issue critical bug fixes also for buster a. k. a. oldstable. 

This means that while the catalog basically is constant w  r  t Buster builds we should still keep the possibility to make Buster builds which are used on Bionic.

To that end the builds here are governed by a  new config file _build-conf.sh_. The default setup is to make a build every tenth run without uploading anything. This can be modified as needed in _build-conf.sh_.