### PR TITLE
CMakeLists: Don't use different package name for wx32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,6 @@ include(Plugin.cmake)
 
 # -------- Setup completed, build the plugin --------
 #
-if ("${OCPN_TARGET_TUPLE}" MATCHES wx32)
-  # Evil, dirty hack to force a different name for wx32 builds. We
-  # need a cleaner solution here. FIXME(leamas)
-  set(PKG_NAME "${PKG_NAME}-wx32")
-endif ()
 project(${PKG_NAME} VERSION ${PKG_VERSION})
 include(PluginCompiler)
 


### PR DESCRIPTION
As heading says: Using a separate name for the wx32 package seemed like a good idea, but it was not. Hopefully, this makes the wx32 package installable. 