### PR TITLE
.circleci/config: Remove duplicated bullseye-armhf entries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,9 +262,6 @@ workflows:
       - build-bullseye-wx32-arm64:
           <<: *std-filters
 
-      - build-bullseye-wx32-armhf:
-          <<: *std-filters
-
       - build-bullseye:
           <<: *std-filters
 


### PR DESCRIPTION
As heading says: Don't build debian-bullseye-armhf twice.