### PR TITLE
Macos v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,7 @@ flatpak-steps: &flatpak-steps
   steps:
     - checkout
     - restore_cache:
-        keys:
-          - <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
+        key: <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
     - run: ci/circleci-build-flatpak.sh
     - save_cache:
         key: <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
@@ -200,7 +199,18 @@ jobs:
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
+      - run: sudo chmod go+w /usr/local
+      - restore_cache:
+          key: "{{checksum \"build-deps/macos-cache-stamp\"}}\
+            -{{checksum \"cmake/MacosWxwidgets.cmake\"}}\
+            -{{checksum \"ci/circleci-build-macos.sh\"}}"
       - run: ci/circleci-build-macos.sh
+      - save_cache:
+          key: "{{checksum \"build-deps/macos-cache-stamp\"}}\
+            -{{checksum \"cmake/MacosWxwidgets.cmake\"}}\
+            -{{checksum \"ci/circleci-build-macos.sh\"}}"
+          paths:
+            - /tmp/local.cache.tar
       - run: >
           sh -c "otool -L build-osx/app/*/OpenCPN.app/Contents/PlugIns/*.dylib"
       - run: cd build-osx; /bin/bash < upload.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,12 @@ flatpak-steps: &flatpak-steps
   steps:
     - checkout
     - restore_cache:
-        key: <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
+        key: "<<parameters.cache-key>>
+          -{{ checksum \"ci/circleci-build-flatpak.sh\" }}"
     - run: ci/circleci-build-flatpak.sh
     - save_cache:
-        key: <<parameters.cache-key>>-{{ checksum "ci/circleci-build-flatpak.sh" }}
+        key: "<<parameters.cache-key>>
+          -{{ checksum \"ci/circleci-build-flatpak.sh\" }}"
         paths:
           - /home/circleci/.local/share/flatpak/repo
     - run: cd /build-flatpak; /bin/bash < upload.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,13 @@ if ("${BUILD_TYPE}" STREQUAL "")
   return ()
 endif ()
 
+ 
 if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   # Build package as required (flatpak already dealt with).
   #
+  if (APPLE)
+    include(MacosWxwidgets)
+  endif ()
   include(PluginInstall)
   if (QT_ANDROID)
     include(AndroidLibs)
@@ -88,7 +92,7 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   include(PluginLocalization)
 
   include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
-
+ 
   if (COMMAND add_plugin_libraries)
     add_plugin_libraries()
   endif ()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,3 +57,20 @@ The initial `set PATH=...` file strips down %PATH% to a very small path,
 excluding most if not all otherwise available tools. In many cases this is
 neither required nor convenient and can be excluded. However, doing it
 represents a tested baseline.
+
+#### Building for Buster (Debian 9)
+
+The Buster builds are targeting Ubuntu Bionic besides Debian Buster. These
+are kept in a legacy state, the basic idea is that buster builds in the
+catalog should not be updated except in case of serious bug fixes.
+
+Plugins could either disable buster builds completely, always run them or
+just run them for example every tenth build. This is configured in the file
+_build-conf.rc_, see comments in this file for details.
+
+#### Building for Macos
+
+The macos build uses a quite aggressive caching scheme. In case of problems
+it might be necessary to invalidate the cache so new dependencies are
+downloaded and built from source. This is done in the file
+_build-deps/macos-cache-stamp_, see comments in that file.

--- a/build-deps/macos-cache-stamp
+++ b/build-deps/macos-cache-stamp
@@ -1,0 +1,4 @@
+# Any change in this file will cause the macos cache to be invalidated
+# i. e., that the homebrew dependencies are downloaded and wxwidgets
+# rebuilt. For example, change the stock 'v1' to 'v2'
+v1

--- a/build-deps/macos-deps
+++ b/build-deps/macos-deps
@@ -5,4 +5,3 @@ libexif
 python
 wget
 openssl@3
-wxwidgets

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -11,7 +11,7 @@
 # the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 
-set -xe
+set -x
 
 # Load local environment if it exists i. e., this is a local build
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
@@ -63,7 +63,9 @@ if [[ -z "$CI" ]]; then
     exit 0
 fi
 
-make VERBOSE=1 tarball
+# nor-reproducible error on first invocation, seemingly tarball-conf-stamp
+# is not created as required.
+make VERBOSE=1 tarball || make VERBOSE=1 tarball
 
 # Install cloudsmith needed by upload script
 python3 -m pip install -q --user cloudsmith-cli

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -49,6 +49,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX= \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+  -DOCPN_TARGET_TUPLE="darwin-wx32;10;x86_64" \
   ..
 
 if [[ -z "$CI" ]]; then

--- a/cmake/MacosWxwidgets.cmake
+++ b/cmake/MacosWxwidgets.cmake
@@ -47,7 +47,7 @@ execute_process(
       --with-opengl
       --without-subdirs
       --prefix=/usr/local
-      WORKING_DIRECTORY ${wxwidgets_src_dir}
+ WORKING_DIRECTORY ${wxwidgets_src_dir}
 )
 math(_nproc ${OPCN_NPROC} * 2)    # Assuming two threads/cpu
 execute_process(

--- a/cmake/MacosWxwidgets.cmake
+++ b/cmake/MacosWxwidgets.cmake
@@ -1,0 +1,60 @@
+# ~~~
+# Summary:     If required, rebuild wxwidgets for macos from source.
+# License:     GPLv3+
+# Copyright (c) 2022 Alec Leamas
+# ~~~
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+cmake_minimum_required(VERSION 3.20.0)
+
+execute_process(
+  COMMAND wx-config --version
+  RESULT_VARIABLE wx_status
+  ERROR_FILE /dev/null
+  COMMAND_ECHO STDOUT
+)
+
+if (${wx_status} EQUAL 0)
+  return ()
+endif ()
+
+include(FetchContent)
+
+FetchContent_Declare(
+  wxwidgets
+  GIT_REPOSITORY https://github.com/wxWidgets/wxWidgets.git
+  GIT_TAG v3.2.1
+)
+FetchContent_Populate(wxwidgets)
+FetchContent_GetProperties(wxwidgets SOURCE_DIR wxwidgets_src_dir)
+
+execute_process(
+  COMMAND git submodule update --init 3rdparty/pcre
+  WORKING_DIRECTORY ${wxwidgets_src_dir}
+)
+execute_process(
+ COMMAND ./configure
+      --with-cxx=11
+      --with-macosx-version-min=10.10
+      --enable-unicode
+      --with-osx-cocoa
+      --enable-aui
+      --disable-debug
+      --with-opengl
+      --without-subdirs
+      --prefix=/usr/local
+      WORKING_DIRECTORY ${wxwidgets_src_dir}
+)
+math(_nproc ${OPCN_NPROC} * 2)    # Assuming two threads/cpu
+execute_process(
+  COMMAND make -j${_nproc}
+  WORKING_DIRECTORY ${wxwidgets_src_dir}
+)
+execute_process(
+  COMMAND sudo make install
+  WORKING_DIRECTORY ${wxwidgets_src_dir}
+)

--- a/update-templates
+++ b/update-templates
@@ -191,7 +191,9 @@ grep -q wxwidgets build-deps/macos-deps || \
     echo wxwidgets >> build-deps/macos-deps
 
 # Check for files/dirs which are private, but should be copied on first run.
-for f in config.h.in build-deps build-conf.sh libs; do
+for f in  \
+    config.h.in build-deps build-conf.sh libs build-deps/macos-cache-stamp
+do
     if test -e $f; then continue; fi
     git checkout $source_treeish $f
 done


### PR DESCRIPTION
I still hesitate to use Dave's completely undocumented tarball. Once it becomes documented things might change.

This version rebuilds wxWidgets form source. This takes a long time (~25 minutes), so to keep build times sane I have also re-enabled the caching. For me, all builds except the first now builds in about 3 minutes which is much faster than the existing macos builds.

Of course, this needs testing to see  that the  compilation flags I got from Dave actually matches what's in OpenCPN i.e., that the tarballs generated this way can be loaded into current OpenCPN