### PR TITLE
3.2.0 v3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,10 @@ To build an android armhf tarball
     $ cmake -DCMAKE_TOOLCHAIN_FILE=cmake/android-armhf-toolchain.cmake ..
     $ make
 
+The Android builds are governed by _build-conf.rc_ and can be disabled or
+just work in dry-run mode without uploading anything. See the file for
+details.
+
 #### Building on windows (MSVC)
 On Windows, build is performed in the _build_ directory using a CMD shell:
 
@@ -68,9 +72,14 @@ Plugins could either disable buster builds completely, always run them or
 just run them for example every tenth build. This is configured in the file
 _build-conf.rc_, see comments in this file for details.
 
-#### Building for Macos
+By default, these builds runs every tenth build without uploading anything.
+
+#### Building for MacOS
 
 The macos build uses a quite aggressive caching scheme. In case of problems
 it might be necessary to invalidate the cache so new dependencies are
 downloaded and built from source. This is done in the file
 _build-deps/macos-cache-stamp_, see comments in that file.
+
+Note that the initial MacOS build takes a long time. However, subsequent
+builds runs at roughly the same time as other platforms.

--- a/update-templates
+++ b/update-templates
@@ -192,7 +192,12 @@ grep -q wxwidgets build-deps/macos-deps || \
 
 # Check for files/dirs which are private, but should be copied on first run.
 for f in  \
-    config.h.in build-deps build-conf.rc libs build-deps/macos-cache-stamp
+    config.h.in \
+    build-deps \
+    build-conf.rc \
+    libs \
+    build-deps/macos-cache-stamp \
+    build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
 do
     if test -e $f; then continue; fi
     git checkout $source_treeish $f

--- a/update-templates
+++ b/update-templates
@@ -186,10 +186,6 @@ git diff-index --quiet --cached HEAD -- || {
     git commit -m "opencpn-libs: Update to latest version."
 }
 
-# Macos: make sure that required wxwidgets is present in build-deps/macos-deps
-grep -q wxwidgets build-deps/macos-deps || \
-    echo wxwidgets >> build-deps/macos-deps
-
 # Check for files/dirs which are private, but should be copied on first run.
 for f in  \
     config.h.in \


### PR DESCRIPTION
update-templates fixes for 3.2.0:
  - Don't add wxwidgets to macos-deps.
  - Handle the patch in build-deps/
  - Some more polish to INSTALL.md


With these changes my "complicated" test case radar_pi seems to work fine. 