### PR TITLE
circleci: Add missing build build-bullseye-wx32-armhf (#481).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,9 @@ workflows:
       - build-bullseye-wx32-arm64:
           <<: *std-filters
 
+      - build-bullseye-wx32-armhf:
+          <<: *std-filters
+
       - build-bullseye:
           <<: *std-filters
 


### PR DESCRIPTION
Closes: #481