### PR TITLE
ci: appveyor: Handle different VS locations.

### DIFF
--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -15,10 +15,11 @@ call %SCRIPTDIR%..\cache\wx-config.bat
 echo USING wxWidgets_LIB_DIR: !wxWidgets_LIB_DIR!
 echo USING wxWidgets_ROOT_DIR: !wxWidgets_ROOT_DIR!
 
-where dumpbin.exe  >nul 2>&1
-if errorlevel 1 (
-  set "VS_HOME=C:\Program Files\Microsoft Visual Studio\2022"
-  call "%VS_HOME%\Community\VC\Auxiliary\Build\vcvars32.bat"
+if not defined VCINSTALLDIR (
+  for /f "tokens=* USEBACKQ" %%p in (
+    `"%programfiles(x86)%\Microsoft Visual Studio\Installer\vswhere" ^
+    -latest -property installationPath`
+  ) do call "%%p\Common7\Tools\vsDevCmd.bat"
 )
 
 if exist build (rmdir /s /q build)


### PR DESCRIPTION
Instead if blindly hardcoding the assumed path to Visual Studio use official mechanisms to resolve it. Instead of using the more or less deprecated  vcvars32.bat use the modern VsDevCmd.bat, available since VS 2017.

This is as used in main OpenCPN.