### PR TITLE
Signing keys (#486, #487)

### DIFF
--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -15,10 +15,11 @@ call %SCRIPTDIR%..\cache\wx-config.bat
 echo USING wxWidgets_LIB_DIR: !wxWidgets_LIB_DIR!
 echo USING wxWidgets_ROOT_DIR: !wxWidgets_ROOT_DIR!
 
-where dumpbin.exe  >nul 2>&1
-if errorlevel 1 (
-  set "VS_HOME=C:\Program Files\Microsoft Visual Studio\2022"
-  call "%VS_HOME%\Community\VC\Auxiliary\Build\vcvars32.bat"
+if not defined VCINSTALLDIR (
+  for /f "tokens=* USEBACKQ" %%p in (
+    `"%programfiles(x86)%\Microsoft Visual Studio\Installer\vswhere" ^
+    -latest -property installationPath`
+  ) do call "%%p\Common7\Tools\vsDevCmd.bat"
 )
 
 if exist build (rmdir /s /q build)

--- a/ci/circleci-build-android.sh
+++ b/ci/circleci-build-android.sh
@@ -25,6 +25,10 @@ fi
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
 if [ -d /ci-source ]; then cd /ci-source; fi
 
+# Handle possible outdated key for google packages, see #487
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | sudo apt-key add -
+
 git submodule update --init opencpn-libs
 
 # Set up build directory and a visible link in /

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -39,6 +39,11 @@ if [ -n "$CI" ]; then
     # Avoid using outdated TLS certificates, see #210.
     sudo apt install --reinstall  ca-certificates
 
+    # Handle possible outdated key for google packages, see #486
+    curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+        | sudo apt-key add -
+
     # Use updated flatpak (#457)
     sudo add-apt-repository -y ppa:alexlarsson/flatpak
     sudo apt update


### PR DESCRIPTION
A lot of signing keys are updated, perhaps due to new year, perhaps  the CircleCI security incident reported where keys was compromised.

This closes #487. As for #486, it moves things forward making it possible to add the PPA again. However, this reveals new issues hopefully resolved on the flatpak mailing list.