### PR TITLE
Debian armhf builds: Fix handling of CLOUDSMITH_BETA_REPO environment var (#498)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ jobs:
             -{{checksum \"ci/circleci-build-macos.sh\"}}"
           paths:
             - /tmp/local.cache.tar
+            - /Users/distiller/project/cache
       - run: >
           sh -c "otool -L build-osx/app/*/OpenCPN.app/Contents/PlugIns/*.dylib"
       - run: cd build-osx; /bin/bash < upload.sh

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -127,7 +127,7 @@ fi
 docker run --rm --privileged multiarch/qemu-user-static:register --reset || :
 docker run --platform linux/arm/v7 --privileged \
     -e "CLOUDSMITH_STABLE_REPO=$CLOUDSMITH_STABLE_REPO" \
-    -e "CLOUDSMITH_BETA_REPO=$OCPN_BETA_REPO" \
+    -e "CLOUDSMITH_BETA_REPO=$CLOUDSMITH_BETA_REPO" \
     -e "CLOUDSMITH_UNSTABLE_REPO=$CLOUDSMITH_UNSTABLE_REPO" \
     -e "CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM" \
     -e "TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER" \

--- a/cmake/MacosWxwidgets.cmake
+++ b/cmake/MacosWxwidgets.cmake
@@ -11,24 +11,58 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-execute_process(
-  COMMAND wx-config --version
-  RESULT_VARIABLE wx_status
-  ERROR_FILE /dev/null
-  COMMAND_ECHO STDOUT
-)
+set(wx_repo https://github.com/wxWidgets/wxWidgets.git)
+set(wx_tag  v3.2.1)
 
-if (${wx_status} EQUAL 0)
+option(IGNORE_SYSTEM_WX "Never use system wxWidgets installation" FALSE)
+
+# Check if we have done the wxWidgets build already
+#
+if (DEFINED wx_config)
   return ()
 endif ()
 
-include(FetchContent)
+# Check if there is a usable wxwidgets anyway
+#
+set(cache_dir ${PROJECT_SOURCE_DIR}/cache)
 
-FetchContent_Declare(
-  wxwidgets
-  GIT_REPOSITORY https://github.com/wxWidgets/wxWidgets.git
-  GIT_TAG v3.2.1
-)
+if (IGNORE_SYSTEM_WX)
+  set(WX_CONFIG_PROG ${cache_dir}/lib/wx/config/osx_cocoa-unicode-3.2)
+else ()
+  find_program(
+    WX_CONFIG_PROG NAMES wx-config osx_cocoa-unicode-3.2
+    HINTS ${PROJECT_SOURCE_DIR}/cache/lib/wx/config /usr/local/lib/wx/config
+  )
+endif ()
+if (WX_CONFIG_PROG)
+  execute_process(
+    COMMAND ${WX_CONFIG_PROG} --version
+    RESULT_VARIABLE wx_status
+    OUTPUT_VARIABLE wx_version
+    ERROR_FILE /dev/null
+    COMMAND_ECHO STDOUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else ()
+  set(wx_status 1)
+endif ()
+
+if (${wx_status} EQUAL 0)
+  set(wx_config ${WX_CONFIG_PROG} CACHE FILEPATH "")
+  set(ENV{WX_CONFIG} ${WX_CONFIG_PROG})
+  if (${wx_version} VERSION_GREATER_EQUAL 3.2)
+    return ()
+  endif ()
+endif ()
+
+if (NOT EXISTS ${cache_dir})
+  file(MAKE_DIRECTORY ${cache_dir})
+endif ()
+
+# Download sources and get the source directory
+#
+include(FetchContent)
+FetchContent_Declare(wxwidgets GIT_REPOSITORY ${wx_repo} GIT_TAG ${wx_tag})
 FetchContent_Populate(wxwidgets)
 FetchContent_GetProperties(wxwidgets SOURCE_DIR wxwidgets_src_dir)
 
@@ -46,7 +80,7 @@ execute_process(
       --disable-debug
       --with-opengl
       --without-subdirs
-      --prefix=/usr/local
+      --prefix=${cache_dir}
  WORKING_DIRECTORY ${wxwidgets_src_dir}
 )
 math(_nproc ${OPCN_NPROC} * 2)    # Assuming two threads/cpu
@@ -58,3 +92,9 @@ execute_process(
   COMMAND sudo make install
   WORKING_DIRECTORY ${wxwidgets_src_dir}
 )
+
+set(wx_config ${cache_dir}/lib/wx/config/osx_cocoa-unicode-3.2)
+if (NOT EXISTS ${wx_config})
+  message(FATAL_ERROR "Cannot locate wx-config tool at ${wx_config}")
+endif ()
+set(ENV{WX_CONFIG} ${wx_config})


### PR DESCRIPTION
#498 is actually an odd  corner case, triggered only on builds tagged with a beta tag AND using the CLOUDSMITH_BETA_REPO environment variable to relocate the upload repository. In short, it probably only hits me.

Closes: #498