### PR TITLE
Use wxWidgets 3.2.2, verify checksums, fix flatpak

### DIFF
--- a/ci/circleci-build-buster-armhf.sh
+++ b/ci/circleci-build-buster-armhf.sh
@@ -52,7 +52,7 @@ apt install -y ./cmake_3.19.3-0.1_armhf.deb ./cmake-data_3.19.3-0.1_all.deb
 
 cd /ci-source
 rm -rf build-debian; mkdir build-debian; cd build-debian
-cmake -DCMAKE_BUILD_TYPE=Release -DOCPN_TARGET_TUPLE="debian;10;armhf" ..
+cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" -DOCPN_TARGET_TUPLE="debian;10;armhf" ..
 make -j $(nproc) VERBOSE=1 tarball
 ldd  app/*/lib/opencpn/*.so
 chown --reference=.. .

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -103,7 +103,7 @@ chown root:root /ci-source
 git config --global --add safe.directory /ci-source
 
 rm -rf build-debian; mkdir build-debian; cd build-debian
-cmake -DCMAKE_BUILD_TYPE=Release -DOCPN_TARGET_TUPLE="@TARGET_TUPLE@" ..
+cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" -DOCPN_TARGET_TUPLE="@TARGET_TUPLE@" ..
 make -j $(nproc) VERBOSE=1 tarball
 ldd  app/*/lib/opencpn/*.so
 

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -44,30 +44,27 @@ function remove_wx30() {
 function install_wx32() {
   test -d /usr/local/pkg || mkdir /usr/local/pkg
   chmod a+w /usr/local/pkg
-  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets"
+  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.1+dfsg-1~bpo11+1"
+  vers="3.2.2+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
-  wget  $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
-  wget  $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
-  wget  $repo/$head/w/wx/wx-common_3.2.1+dfsg-1~bpo11+1/wx-common_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk-webview3.2-dev_3.2.1+dfsg-1~bpo11+1/libwxgtk-webview3.2-dev_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk-webview3.2-0_3.2.1+dfsg-1~bpo11+1/libwxgtk-webview3.2-0_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1~bpo11+1/libwxgtk-media3.2-dev_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk3.2-dev_3.2.1+dfsg-1~bpo11+1/libwxgtk3.2-dev_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk3.2-0_3.2.1+dfsg-1~bpo11+1/libwxgtk3.2-0_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxbase3.2-0_3.2.1+dfsg-1~bpo11+1/libwxbase3.2-0_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1~bpo11+1/libwxgtk-media3.2-dev_3.2.1+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxsvg-dev_2:1.5.23+dfsg-1~bpo11+1/libwxsvg-dev_1.5.23+dfsg-1~bpo11+1_armhf.deb
-  wget  $repo/$head/l/li/libwxsvg3_2:1.5.23+dfsg-1~bpo11+1/libwxsvg3_1.5.23+dfsg-1~bpo11+1_armhf.deb
+  wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_armhf.deb
+  wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
+  wget -q $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
+  wget -q $repo/$head/l/li/libwxgtk-webview3.2-dev_${vers}/libwxgtk-webview3.2-dev_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk-webview3.2-1_${vers}/libwxgtk-webview3.2-1_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk-media3.2-dev_${vers}/libwxgtk-media3.2-dev_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk3.2-dev_${vers}/libwxgtk3.2-dev_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk3.2-1_${vers}/libwxgtk3.2-1_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk-gl3.2-1_${vers}/libwxgtk-gl3.2-1_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxbase3.2-1_${vers}/libwxbase3.2-1_${vers}_armhf.deb
+  wget -q $repo/$head/l/li/libwxgtk-media3.2-1_${vers}/libwxgtk-media3.2-1_${vers}_armhf.deb
 
   dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
   sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/*-linux-*/wx/config/gtk3-unicode-3.2
 
-  # See wxWidgets#22790. FIXME (leamas) To be removed after wxw 3.2.3
-  cd /usr/include/wx-3.2/wx/
-  patch -p1 < /ci-source/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
+  # wxWidgets#22790 patch no longer needed in wx3.2.2.1
 
   popd
 }

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -44,29 +44,28 @@ function remove_wx30() {
 function install_wx32() {
   test -d /usr/local/pkg || mkdir /usr/local/pkg
   chmod a+w /usr/local/pkg
-  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets"
+  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.1+dfsg-1~bpo11+1"
+  vers="3.2.2+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
-  wget  $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
-  wget  $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
-  wget  $repo/$head/w/wx/wx-common_3.2.1+dfsg-1/wx-common_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxgtk-webview3.2-dev_3.2.1+dfsg-1/libwxgtk-webview3.2-dev_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxgtk-webview3.2-0_3.2.1+dfsg-1/libwxgtk-webview3.2-0_3.2.1+dfsg-1_arm64.deb 
-  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1/libwxgtk-media3.2-dev_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxgtk3.2-dev_3.2.1+dfsg-1/libwxgtk3.2-dev_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxgtk3.2-0_3.2.1+dfsg-1/libwxgtk3.2-0_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxbase3.2-0_3.2.1+dfsg-1/libwxbase3.2-0_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxgtk-media3.2-dev_3.2.1+dfsg-1/libwxgtk-media3.2-dev_3.2.1+dfsg-1_arm64.deb
-  wget  $repo/$head/l/li/libwxsvg-dev_2:1.5.23+dfsg-1~bpo11+1/libwxsvg-dev_1.5.23+dfsg-1~bpo11+1_arm64.deb
-  wget  $repo/$head/l/li/libwxsvg3_2:1.5.23+dfsg-1~bpo11+1/libwxsvg3_1.5.23+dfsg-1~bpo11+1_arm64.deb
+  wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_arm64.deb
+  wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
+  wget -q $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
+  wget -q $repo/$head/l/li/libwxgtk-webview3.2-dev_${vers}/libwxgtk-webview3.2-dev_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk-webview3.2-1_${vers}/libwxgtk-webview3.2-1_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk-media3.2-dev_${vers}/libwxgtk-media3.2-dev_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk3.2-dev_${vers}/libwxgtk3.2-dev_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk3.2-1_${vers}/libwxgtk3.2-1_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk-gl3.2-1_${vers}/libwxgtk-gl3.2-1_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxbase3.2-1_${vers}/libwxbase3.2-1_${vers}_arm64.deb
+  wget -q $repo/$head/l/li/libwxgtk-media3.2-1_${vers}/libwxgtk-media3.2-1_${vers}_arm64.deb
+
   dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
   sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/*-linux-gnu/wx/config/gtk3-unicode-3.2
 
-  # See wxWidgets#22790. FIXME (leamas) To be removed after wxw 3.2.3
-  cd /usr/include/wx-3.2/wx/
-  patch -p1 < /ci-source/build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
+  # wxWidgets#22790 patch no longer needed in wx3.2.2.1
+
   popd
 }
 

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -113,11 +113,8 @@ cd /
 setfacl --restore=/ci-source.permissions
 EOF
 
-if [ -n "$BUILD_WX32" ]; then OCPN_WX_ABI_OPT="-DOCPN_WX_ABI=wx32"; fi
-
 sed -i "s/@TARGET_TUPLE@/$TARGET_TUPLE/" $ci_source/build.sh
 sed -i "s/@BUILD_WX32@/$BUILD_WX32/" $ci_source/build.sh
-
 
 # Run script in docker image
 #

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -100,7 +100,7 @@ chown root:root /ci-source
 git config --global --add safe.directory /ci-source
 
 rm -rf build-debian; mkdir build-debian; cd build-debian
-cmake -DCMAKE_BUILD_TYPE=Release\
+cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" \
    -DOCPN_TARGET_TUPLE="@TARGET_TUPLE@" \
     ..
 

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -100,7 +100,7 @@ python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 
 cd $builddir
 
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo $TARGET_OPT ..
+cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDbgInfo}" $TARGET_OPT ..
 make VERBOSE=1 tarball
 ldd app/*/lib/opencpn/*.so
 if [ -d /ci-source ]; then

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -32,30 +32,29 @@ function remove_wx30() {
 function install_wx32() {
   test -d /usr/local/pkg || sudo mkdir /usr/local/pkg
   sudo chmod a+w /usr/local/pkg
-  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets"
+  repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.1+dfsg-1~bpo11+1"
+  vers="3.2.2+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
   wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_amd64.deb
   wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb
   wget -q $repo/$head/w/wx/wx3.2-headers_${vers}/wx3.2-headers_${vers}_all.deb
   wget -q $repo/$head/l/li/libwxgtk-webview3.2-dev_${vers}/libwxgtk-webview3.2-dev_${vers}_amd64.deb
-  wget -q $repo/$head/l/li/libwxgtk-webview3.2-0_${vers}/libwxgtk-webview3.2-0_${vers}_amd64.deb
+  wget -q $repo/$head/l/li/libwxgtk-webview3.2-1_${vers}/libwxgtk-webview3.2-1_${vers}_amd64.deb
   wget -q $repo/$head/l/li/libwxgtk-media3.2-dev_${vers}/libwxgtk-media3.2-dev_${vers}_amd64.deb
   wget -q $repo/$head/l/li/libwxgtk3.2-dev_${vers}/libwxgtk3.2-dev_${vers}_amd64.deb
-  wget -q $repo/$head/l/li/libwxgtk3.2-0_${vers}/libwxgtk3.2-0_${vers}_amd64.deb
-  wget -q $repo/$head/l/li/libwxbase3.2-0_${vers}/libwxbase3.2-0_${vers}_amd64.deb
-  wget -q $repo/$head/l/li/libwxgtk-media3.2-0_${vers}/libwxgtk-media3.2-0_${vers}_amd64.deb
-  wget -q $repo/$head/l/li/libwxsvg-dev_2:1.5.23+dfsg-1~bpo11+1/libwxsvg-dev_1.5.23+dfsg-1~bpo11+1_amd64.deb
-  wget -q $repo/$head/l/li/libwxsvg3_2:1.5.23+dfsg-1~bpo11+1/libwxsvg3_1.5.23+dfsg-1~bpo11+1_amd64.deb
+  wget -q $repo/$head/l/li/libwxgtk3.2-1_${vers}/libwxgtk3.2-1_${vers}_amd64.deb
+  wget -q $repo/$head/l/li/libwxgtk-gl3.2-1_${vers}/libwxgtk-gl3.2-1_${vers}_amd64.deb
+  wget -q $repo/$head/l/li/libwxbase3.2-1_${vers}/libwxbase3.2-1_${vers}_amd64.deb
+  wget -q $repo/$head/l/li/libwxgtk-media3.2-1_${vers}/libwxgtk-media3.2-1_${vers}_amd64.deb
+
   sudo dpkg -i --force-depends $(ls /usr/local/pkg/*deb)
   sudo apt --fix-broken install
   sudo sed -i '/^user_mask_fits/s|{.*}|{ /bin/true; }|' \
       /usr/lib/$(uname -m)-linux-gnu/wx/config/gtk3-unicode-3.2
-  # See wxWidgets#22790. To be removed after wxw 3.2.3
-  cd /usr/include/wx-3.2/wx/
-  sudo patch -p1 \
-    < $here/../build-deps/0001-matrix.h-Patch-attributes-handling-wxwidgets-22790.patch
+
+  # wxWidgets#22790 patch no longer needed in wx3.2.2.1
+
   popd
 }
 

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -83,9 +83,8 @@ mk-build-deps --root-cmd=sudo -ir build-deps/control
 rm -f *changes  *buildinfo
 
 if [ -n "$BUILD_WX32" ]; then
-  remove_wx30;
-  install_wx32;
-  OCPN_WX_ABI_OPT="-DOCPN_WX_ABI=wx32"
+  remove_wx30
+  install_wx32
 fi
 
 if [ -n "$TARGET_TUPLE" ]; then
@@ -101,7 +100,7 @@ python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 
 cd $builddir
 
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo $OCPN_WX_ABI_OPT $TARGET_OPT ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo $TARGET_OPT ..
 make VERBOSE=1 tarball
 ldd app/*/lib/opencpn/*.so
 if [ -d /ci-source ]; then

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -72,7 +72,6 @@ cd $builddir
 
 # Patch the manifest to use correct branch and runtime unconditionally
 manifest=$(ls ../flatpak/org.opencpn.OpenCPN.Plugin*yaml)
-sed -i  '/-DBUILD_TYPE/s/$/ -DOCPN_WX_ABI=wx32/' $manifest
     # FIXME (leamas) restore beta -> stable when O58 is published
 sed -i  '/^runtime-version/s/:.*/: beta/'  $manifest
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -81,7 +81,7 @@ flatpak remote-add --user --if-not-exists \
     flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
 # Configure and build the plugin tarball and metadata.
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} ..
 # Do not build flatpak in parallel; make becomes unreliable
 make -j 1 VERBOSE=1 flatpak
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -82,7 +82,8 @@ flatpak remote-add --user --if-not-exists \
 
 # Configure and build the plugin tarball and metadata.
 cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j $(nproc) VERBOSE=1 flatpak
+# Do not build flatpak in parallel; make becomes unreliable
+make -j 1 VERBOSE=1 flatpak
 
 # Restore permissions and owner in build tree.
 if [ -d /ci-source ]; then sudo chown --reference=/ci-source -R . ../cache; fi

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -51,7 +51,7 @@ export OPENSSL_ROOT_DIR='/usr/local/opt/openssl'
 # Build and package
 cd build-osx
 cmake \
-  -DCMAKE_BUILD_TYPE=Release \
+  "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" \
   -DCMAKE_INSTALL_PREFIX= \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
   -DOCPN_TARGET_TUPLE="darwin-wx32;10;x86_64" \

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -122,17 +122,13 @@ elseif ("${_pkg_arch}" MATCHES "armhf")
   set(_display_arch "-A32")
 endif()
 
-if (NOT "${OCPN_WX_ABI}" STREQUAL "")
-  set(_wx_abi ".${OCPN_WX_ABI}")
-endif ()
-
 if ("${_git_tag}" STREQUAL "")
   set(pkg_displayname "${PLUGIN_API_NAME}-${VERSION_MAJOR}.${VERSION_MINOR}")
 else ()
   set(pkg_displayname "${PLUGIN_API_NAME}-${_git_tag}")
 endif ()
 string(APPEND pkg_displayname
-  "-${plugin_target}${_wx_abi}${_display_arch}-${plugin_target_version}"
+  "-${plugin_target}${_display_arch}-${plugin_target_version}"
 )
 
 # pkg_xmlname: XML metadata basename
@@ -141,7 +137,7 @@ set(pkg_xmlname ${pkg_displayname})
 # pkg_tarname: Tarball basename
 string(CONCAT pkg_tarname
   "${PLUGIN_API_NAME}-${pkg_semver}"
-  "_${plugin_target}${_wx_abi}-${plugin_target_version}-${_pkg_arch}"
+  "_${plugin_target}-${plugin_target_version}-${_pkg_arch}"
 )
 
 # pkg_tarball_url: Tarball location at cloudsmith
@@ -165,9 +161,6 @@ endif ()
 # pkg_target_arch: os + optional -arch suffix. See: Opencpn bug #2003
 if ("${BUILD_TYPE}" STREQUAL "flatpak")
   set(pkg_target_arch "flatpak-${ARCH}")
-  if (NOT "${OCPN_WX_ABI}" STREQUAL "")
-    set(pkg_target_arch "${pkg_target_arch}-${OCPN_WX_ABI}")
-  endif ()
 elseif ("${plugin_target}" MATCHES "ubuntu|raspbian|debian|mingw")
   set(pkg_target_arch "${plugin_target}-${ARCH}")
 else ()


### PR DESCRIPTION
- Build debian-wx32 targets using wxWidgets 3.2.2.1 instead of wx 3.2.1.
- Build flatpak builds with 1 parallel, as I am seeing spurious make errors at 2.
- Allow override of CMAKE_BUILD_TARGET for local builds.
