### PR TITLE
Allow cross- and universal builds on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ endif ()
 #
 include(Plugin.cmake)
 
+# -------- Options --------
+# If only defined in include file CMake seems to ignore them.
+#
+option(MACOS_UNIVERSAL_BUILD "Build for both x86_64 and arm64" FALSE)
+option(IGNORE_SYSTEM_WX "Never use system wxWidgets installation" FALSE)
+
 # -------- Setup completed, build the plugin --------
 #
 project(${PKG_NAME} VERSION ${PKG_VERSION})

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -30,7 +30,7 @@ rm -rf build-osx  && mkdir build-osx
 # Create a log file.
 exec > >(tee build-osx/build.log) 2>&1
 
-export MACOSX_DEPLOYMENT_TARGET=10.10
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.10}
 
 # Return latest version of $1, optionally using option $2
 pkg_version() { brew list --versions $2 $1 | tail -1 | awk '{print $2}'; }
@@ -53,8 +53,9 @@ cd build-osx
 cmake \
   "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" \
   -DCMAKE_INSTALL_PREFIX= \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+  "-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}" \
   -DOCPN_TARGET_TUPLE="darwin-wx32;10;x86_64" \
+  ${CMAKE_EXTRA_OPTIONS:-} \
   ..
 
 if [[ -z "$CI" ]]; then

--- a/cmake/MacosWxwidgets.cmake
+++ b/cmake/MacosWxwidgets.cmake
@@ -14,6 +14,8 @@ cmake_minimum_required(VERSION 3.20.0)
 set(wx_repo https://github.com/wxWidgets/wxWidgets.git)
 set(wx_tag  v3.2.1)
 
+# Re-mention our options
+option(MACOS_UNIVERSAL_BUILD "Build for both x86_64 and arm64" FALSE)
 option(IGNORE_SYSTEM_WX "Never use system wxWidgets installation" FALSE)
 
 # Check if we have done the wxWidgets build already
@@ -66,32 +68,59 @@ FetchContent_Declare(wxwidgets GIT_REPOSITORY ${wx_repo} GIT_TAG ${wx_tag})
 FetchContent_Populate(wxwidgets)
 FetchContent_GetProperties(wxwidgets SOURCE_DIR wxwidgets_src_dir)
 
+if (MACOS_UNIVERSAL_BUILD)
+  set(configure_universal_build_arg "--enable-macosx_arch=x86_64,arm64")
+  set(configure_syslib_arg "--disable-sys-libs")
+  set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+endif()
+
 execute_process(
   COMMAND git submodule update --init 3rdparty/pcre
   WORKING_DIRECTORY ${wxwidgets_src_dir}
+  RESULT_VARIABLE status
 )
+if (${status} GREATER 0)
+  message( FATAL_ERROR "Unable to update pcre submodule")
+endif()
+
 execute_process(
- COMMAND ./configure
+  COMMAND ./configure
       --with-cxx=11
-      --with-macosx-version-min=10.10
+      --with-macosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}
       --enable-unicode
+      ${configure_universal_build_arg}
+      ${configure_syslib_arg}
       --with-osx-cocoa
       --enable-aui
       --disable-debug
       --with-opengl
       --without-subdirs
       --prefix=${cache_dir}
- WORKING_DIRECTORY ${wxwidgets_src_dir}
+  WORKING_DIRECTORY ${wxwidgets_src_dir}
+  RESULT_VARIABLE status
 )
+if (status AND NOT status EQUAL 0)
+  message( FATAL_ERROR "Error in wxWidgets configure: ${status}")
+endif()
+
 math(_nproc ${OCPN_NPROC} * 2)    # Assuming two threads/cpu
 execute_process(
   COMMAND make -j${_nproc}
   WORKING_DIRECTORY ${wxwidgets_src_dir}
+  RESULT_VARIABLE status
 )
+if (status AND NOT status EQUAL 0)
+  message( FATAL_ERROR "Error in wxWidgets make: ${status}")
+endif()
+
 execute_process(
   COMMAND sudo make install
   WORKING_DIRECTORY ${wxwidgets_src_dir}
+  RESULT_VARIABLE status
 )
+if (status AND NOT status EQUAL 0)
+  message( FATAL_ERROR "Error in wxWidgets install: ${status}")
+endif()
 
 set(wx_config ${cache_dir}/lib/wx/config/osx_cocoa-unicode-3.2)
 if (NOT EXISTS ${wx_config})


### PR DESCRIPTION
* Allow universal build of wxWidgets.
* Allow universal and cross-builds of plugin.
* Fix passing of MACOSX_DEPLOYMENT_TARGET to wxWidgets and plugin build.

To make a universal build (both x86_64 and arm64), on either x86_64 or arm64, set the following in `.config/local-build.rc`:

   CMAKE_EXTRA_OPTIONS='-DIGNORE_SYSTEM_WX=TRUE -DMACOS_UNIVERSAL_BUILD=TRUE -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'

To create a cross-build on arm64 to x86_64:

   CMAKE_EXTRA_OPTIONS='-DIGNORE_SYSTEM_WX=TRUE -DMACOS_UNIVERSAL_BUILD=TRUE -DCMAKE_OSX_ARCHITECTURES=x86_64'

Or the other way around to build arm64 on x86_64, but that is not an envisioned scenario I guess.

Note that the wxWidgets code is still built in universal mode even if just cross-compiling; the compiling overhead is not that big and it makes no difference for the plugin package.