### PR TITLE
Generalize target name generation on Linux

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -161,7 +161,7 @@ endif ()
 # pkg_target_arch: os + optional -arch suffix. See: Opencpn bug #2003
 if ("${BUILD_TYPE}" STREQUAL "flatpak")
   set(pkg_target_arch "flatpak-${ARCH}")
-elseif ("${plugin_target}" MATCHES "ubuntu|raspbian|debian|mingw")
+elseif (lsb_linux OR "${plugin_target}" MATCHES "mingw")
   set(pkg_target_arch "${plugin_target}-${ARCH}")
 else ()
   set(pkg_target_arch "${plugin_target}")

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -59,6 +59,7 @@ elseif (UNIX)
     OUTPUT_VARIABLE plugin_target_version
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+  set(lsb_linux ON)
 else ()
   set(plugin_target "unknown")
   set(plugin_target_version 1)


### PR DESCRIPTION
This patch makes any Linux machine generate usable plugin metadata with target correctly including the architecture, regardless of the distribution used. It makes development and testing on "unsupported" systems, eg. Fedora a tad simpler as the locally built plugin artifacts are directly usable in locally built OpenCPN.