### PR TITLE
Use urllib < 2.0.0  (#520)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 3.3.0 TBD
 * Fix wrong upload directory for bookworm plugins (#492).
 * Fix handling of wxWidgets 3.2 build deps in update-templates (#490).
+* Use urllib3 < 2.0.0 (#520).
 * Update opencpn-libs,
     - Provide a compatility target ocpn::api on api-18.
     - Fix bug in nmea0183 lib, see

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -140,6 +140,7 @@ if pyenv versions &>/dev/null;  then
     pyenv versions | tr -d '*' | awk '{print $1}' | tail -1 \
         > $HOME/.python-version
 fi
+python3 -m pip install -q --user "urllib3<2.0.0"   # See #520
 python3 -m pip install -q --user cloudsmith-cli cryptography
 
 # python install scripts in ~/.local/bin, teach upload.sh to use in it's PATH:

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -135,6 +135,7 @@ if pyenv versions &>/dev/null;  then
     pyenv versions | tr -d '*' | awk '{print $1}' | tail -1 \
         > $HOME/.python-version
 fi
+python3 -m pip install -q --user "urllib3<2.0.0"   # See #520
 python3 -m pip install -q --user cloudsmith-cli cryptography
 
 # python install scripts in ~/.local/bin, teach upload.sh to use in it's PATH:

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -95,6 +95,7 @@ sudo apt install -q \
     python3-pip python3-setuptools python3-dev python3-wheel \
     build-essential libssl-dev libffi-dev
 
+python3 -m pip install -q --user "urllib3<2.0.0"   # See #520
 python3 -m pip install --user --upgrade -q setuptools wheel pip
 python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 

--- a/cmake/CmakeSetup.cmake
+++ b/cmake/CmakeSetup.cmake
@@ -10,6 +10,10 @@ if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif ()
 
+if (POLICY CMP0126)
+  cmake_policy(SET CMP0126 NEW)
+endif ()
+
 # Locations where cmake looks for cmake modules.
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/build ${CMAKE_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
The cloudsmith python package is incompatible with version 2.0.0 of urllib3, released end of April. Lock urllib2 to be < 2.0.0 until cloudsmith has updated their package
