### PR TITLE
PluginSeup, Metadata: Remove temporary debug logging.

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -167,6 +167,4 @@ else ()
   set(pkg_target_arch "${plugin_target}")
 endif ()
 
-message(STATUS "Metadata: pkg_target_arch: ${pkg_target_arch}.")
-
 #cmake-format: on

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -14,8 +14,6 @@ if (DEFINED plugin_target)
   return ()
 endif ()
 
-message(STATUS "Setup: OCPN_TARGET_TUPLE: ${OCPN_TARGET_TUPLE}")
-
 if (NOT "${OCPN_TARGET_TUPLE}" STREQUAL "")
   list(GET OCPN_TARGET_TUPLE 0 plugin_target)
   list(GET OCPN_TARGET_TUPLE 1 plugin_target_version)
@@ -66,8 +64,6 @@ else ()
   set(plugin_target "unknown")
   set(plugin_target_version 1)
 endif ()
-
-message(STATUS "Setup: lsb_linux: ${lsb_linux}.")
 
 string(STRIP "${plugin_target}" plugin_target)
 string(TOLOWER "${plugin_target}" plugin_target)


### PR DESCRIPTION
Drop some debugging statements added in #541 since they no longer are useful.

If we overall did log at this level the configuration output would become unlegible. Less is more...