### PR TITLE
Revert #541

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - image: circleci/buildpack-deps:bullseye-scm
     environment:
       - OCPN_TARGET: bullseye
+      - TARGET_TUPLE: debian-x86_64;11;x86_64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
@@ -60,7 +61,7 @@ jobs:
     environment:
       - OCPN_TARGET: bullseye
       - BUILD_WX32: true
-      - TARGET_TUPLE: debian-wx32;11;x86_64
+      - TARGET_TUPLE: debian-wx32-x86_64;11;x86_64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     <<: *debian-steps
 
@@ -69,7 +70,7 @@ jobs:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
     environment:
-      - TARGET_TUPLE: debian;11;armhf
+      - TARGET_TUPLE: debian-armhf;11;armhf
       - OCPN_TARGET: bullseye
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
@@ -83,7 +84,7 @@ jobs:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
     environment:
-      - TARGET_TUPLE: debian-wx32;11;armhf
+      - TARGET_TUPLE: debian-wx32-armhf;11;armhf
       - OCPN_TARGET: bullseye
       - BUILD_WX32: true
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
@@ -100,7 +101,7 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: bullseye
-      - TARGET_TUPLE: debian;11;arm64
+      - TARGET_TUPLE: debian-arm64;11;arm64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
@@ -115,7 +116,7 @@ jobs:
     environment:
       - OCPN_TARGET: bullseye
       - BUILD_WX32: true
-      - TARGET_TUPLE: debian-wx32;11;arm64
+      - TARGET_TUPLE: debian-wx32-arm64;11;arm64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
@@ -130,7 +131,7 @@ jobs:
     resource_class: medium
     environment:
       - OCPN_TARGET: bookworm
-      - TARGET_TUPLE: debian;12;x86_64
+      - TARGET_TUPLE: debian-x86_64;12;x86_64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
@@ -144,7 +145,7 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: bookworm
-      - TARGET_TUPLE: debian;12;arm64
+      - TARGET_TUPLE: debian-arm64;12;arm64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:
       - checkout
@@ -157,7 +158,7 @@ jobs:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
     environment:
-      - TARGET_TUPLE: debian;12;armhf
+      - TARGET_TUPLE: debian-armhf;12;armhf
       - OCPN_TARGET: bookworm
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
     steps:

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -161,7 +161,7 @@ endif ()
 # pkg_target_arch: os + optional -arch suffix. See: Opencpn bug #2003
 if ("${BUILD_TYPE}" STREQUAL "flatpak")
   set(pkg_target_arch "flatpak-${ARCH}")
-elseif (lsb_linux OR "${plugin_target}" MATCHES "mingw|debian-wx32")
+elseif (lsb_linux OR "${plugin_target}" MATCHES "mingw")
   set(pkg_target_arch "${plugin_target}-${ARCH}")
 else ()
   set(pkg_target_arch "${plugin_target}")

--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -167,4 +167,7 @@ else ()
   set(pkg_target_arch "${plugin_target}")
 endif ()
 
+message(STATUS
+  "Building for target:release: ${pkg_target_arch}:${plugin_target_version}"
+)
 #cmake-format: on

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -70,28 +70,6 @@ string(TOLOWER "${plugin_target}" plugin_target)
 string(STRIP "${plugin_target_version}" plugin_target_version)
 string(TOLOWER "${plugin_target_version}" plugin_target_version)
 
-if (plugin_target STREQUAL "ubuntu")
-  if (DEFINED wxWidgets_CONFIG_EXECUTABLE)
-    set(_WX_CONFIG_PROG ${wxWidgets_CONFIG_EXECUTABLE})
-  else ()
-    find_program(_WX_CONFIG_PROG NAMES $ENV{WX_CONFIG} wx-config )
-  endif ()
-  if (_WX_CONFIG_PROG)
-    execute_process(
-      COMMAND ${_WX_CONFIG_PROG} --selected-config
-      OUTPUT_VARIABLE _WX_SELECTED_CONFIG
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if (_WX_SELECTED_CONFIG MATCHES gtk3)
-      if (${plugin_target_version} VERSION_LESS 22.04)
-        set(plugin_target ubuntu-gtk3)
-      endif ()
-    endif ()
-  else ()
-    message(WARNING "Cannot locate wx-config utility")
-  endif ()
-endif ()
-
 string(CONCAT msg "Identified plugin target:release"
   " ${plugin_target}:${plugin_target_version}"
 )

--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -92,7 +92,7 @@ if (plugin_target STREQUAL "ubuntu")
   endif ()
 endif ()
 
-string(CONCAT msg "Building for target-release "
-  "${plugin_target}-${plugin_target_version}"
+string(CONCAT msg "Identified plugin target:release"
+  " ${plugin_target}:${plugin_target_version}"
 )
 message(STATUS "${msg}")


### PR DESCRIPTION
The  fix in #541 does the wrong thing when using OCPN_TARGET_TUPLE. Revert it, to keep things consistent.

This will create the wrong target when doing a plain `cmake ..` in  local build. However, this is less of a problem, we can live with that for now until we have a better fix.