### PR TITLE
Metadata.cmake: Revert bad fix in #541  (#540)

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -161,7 +161,7 @@ endif ()
 # pkg_target_arch: os + optional -arch suffix. See: Opencpn bug #2003
 if ("${BUILD_TYPE}" STREQUAL "flatpak")
   set(pkg_target_arch "flatpak-${ARCH}")
-elseif (lsb_linux OR "${plugin_target}" MATCHES "mingw|debian-wx32")
+elseif (lsb_linux OR "${plugin_target}" MATCHES "mingw")
   set(pkg_target_arch "${plugin_target}-${ARCH}")
 else ()
   set(pkg_target_arch "${plugin_target}")


### PR DESCRIPTION
The  fix in #541 does the wrong thing when using OCPN_TARGET_TUPLE. Revert it, to keep things consistent.

This will create the wrong target when doing a plain `cmake ..` in  local build. However, this is less of a problem, we can live with that for now until we have a better fix.