### PR TITLE
Update android builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
 
   build-android-arm64:
     docker:
-      - image: circleci/android:api-28-ndk
+      - image: cimg/android:2023.08-ndk
     environment:
       - OCPN_TARGET: android-aarch64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
@@ -234,7 +234,7 @@ jobs:
 
   build-android-armhf:
     docker:
-      - image: circleci/android:api-28-ndk
+      - image: cimg/android:2023.08-ndk
     environment:
       - OCPN_TARGET: android-armhf
       - CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/ci/circleci-build-android.sh
+++ b/ci/circleci-build-android.sh
@@ -61,7 +61,9 @@ python3 -m pip install --user -q cmake
 # Build tarball
 cd $builddir
 
-sudo ln -sf /opt/android/android-ndk-* /opt/android/ndk
+last_ndk=$(ls -d /home/circleci/android-sdk/ndk/* | tail -1)
+test -d /opt/android || sudo mkdir -p /opt/android
+sudo ln -sf $last_ndk /opt/android/ndk
 cmake -DCMAKE_TOOLCHAIN_FILE=cmake/$OCPN_TARGET-toolchain.cmake ..
 make VERBOSE=1
 

--- a/cmake/AndroidLibs.cmake
+++ b/cmake/AndroidLibs.cmake
@@ -36,7 +36,7 @@ if (NOT EXISTS ${OCPN_ANDROID_CACHEDIR}/master.zip)
       https://github.com/bdbcat/OCPNAndroidCommon/archive/master.zip
       ${OCPN_ANDROID_CACHEDIR}/master.zip
     EXPECTED_HASH
-      SHA256=a15ebd49fd4e7c0f2d6e99328ed6a9fdb8ed7c8fcaa993cab585fc9d8aab4f56
+      SHA256=b6359260ecfb44b96c0dd4052e41aac505c9e3c4eb7a798b29c17ddbc3c939b3
     SHOW_PROGRESS
   )
 endif ()
@@ -67,14 +67,14 @@ if ("${Qt_Build}" MATCHES "arm64")
     ${_master_base}/wxWidgets/libarm64/wx/include/arm-linux-*-static-*
   )
   set(_qt_include  ${_master_base}/qt5/build_arm64_O3/qtbase/include)
-  set(_libgorp ${_master_base}/opencpn/API-117/libarm64/libgorp.so)
+  set(_libgorp ${_master_base}/opencpn/API-118/libarm64/libgorp.so)
   set(_qtlibs  ${_master_base}/qt5/build_arm64_O3/qtbase/lib)
 else ()
   file(GLOB _wx_setup
     ${_master_base}/wxWidgets/libarmhf/wx/include/arm-linux-*-static-*
   )
   set(_qt_include ${_master_base}/qt5/build_arm32_19_O3/qtbase/include)
-  set(_libgorp ${_master_base}/opencpn/API-117/libarmhf/libgorp.so)
+  set(_libgorp ${_master_base}/opencpn/API-118/libarmhf/libgorp.so)
   set(_qtlibs  ${_master_base}/qt5/build_arm32_19_O3/qtbase/lib)
 endif ()
 

--- a/cmake/android-armhf-toolchain.cmake
+++ b/cmake/android-armhf-toolchain.cmake
@@ -10,7 +10,7 @@
 # (at your option) any later version.
 
 set(CMAKE_SYSTEM_NAME Android)
-set(CMAKE_SYSTEM_VERSION 16)
+set(CMAKE_SYSTEM_VERSION 21)
 set(CMAKE_ANDROID_ARCH_ABI armeabi-v7a)
 if (DEFINED ENV{NDK_HOME})
   set(CMAKE_ANDROID_NDK $ENV{NDK_HOME})


### PR DESCRIPTION
- Update the deprecated circleci android images.
- Update the  mega blob used for linking the plugins to API 1.18