### PR TITLE
config: Use Plugin.cmake data in plugin API (#572)

### DIFF
--- a/FIX_PLUGIN_INFO.md
+++ b/FIX_PLUGIN_INFO.md
@@ -1,0 +1,21 @@
+Fix plugin information
+======================
+
+Upcoming changes in main OpenCPN makes it important to provide correct
+information in the plugin API. In this context, "correct" means using the
+info defined in Plugin.cmake and hence in the plugin catalog.
+
+In order to achieve this, first add these two lines to _config.h.in_:
+
+    #define PKG_SUMMARY _("@PKG_SUMMARY@")
+    #define PKG_DESCRIPTION _(R"""(@PKG_DESCRIPTION@)""")
+
+In the next step redefine the API functions `GetCommonName()`, 
+`GetShortDescription()` and `GetLongDescription()`. In the 
+shipdriver case these lives in _src/Shipdriver_pi.cpp_ and becomes:
+
+    wxString ShipDriver_pi::GetCommonName() { return PLUGIN_API_NAME; }
+    wxString ShipDriver_pi::GetShortDescription() { return PKG_SUMMARY; }
+    wxString ShipDriver_pi::GetLongDescription() { return PKG_DESCRIPTION; }
+
+This is boilerplate code common for all plugins.

--- a/config.h.in
+++ b/config.h.in
@@ -7,6 +7,8 @@
 
 #define PKG_PRERELEASE "@PKG_PRERELEASE@"
 #define PKG_BUILD_INFO "@pkg_vers_build_info@"
+#define PKG_SUMMARY _("@PKG_SUMMARY@")
+#define PKG_DESCRIPTION _(R"""(@PKG_DESCRIPTION@)""")
 
 #define PLUGIN
 

--- a/src/ShipDriver_pi.cpp
+++ b/src/ShipDriver_pi.cpp
@@ -73,7 +73,7 @@ extern "C" DECL_EXP void destroy_pi(opencpn_plugin* p) { delete p; }
  */
 
 static wxBitmap load_plugin(const char* icon_name, const char* api_name) {
-    wxBitmap bitmap; 
+    wxBitmap bitmap;
     wxFileName fn;
     auto path = GetPluginDataDir(api_name);
     fn.SetPath(path);
@@ -82,7 +82,7 @@ static wxBitmap load_plugin(const char* icon_name, const char* api_name) {
 #ifdef ocpnUSE_SVG
     wxLogDebug("Loading SVG icon");
     fn.SetExt("svg");
-    const static int ICON_SIZE = 48;  // FIXME: Needs size from GUI 
+    const static int ICON_SIZE = 48;  // FIXME: Needs size from GUI
     bitmap = GetBitmapFromSVGFile(fn.GetFullPath(), ICON_SIZE, ICON_SIZE);
 #else
     wxLogDebug("Loading png icon");
@@ -99,7 +99,7 @@ static wxBitmap load_plugin(const char* icon_name, const char* api_name) {
     return bitmap;
 }
 
- 
+
 
 ShipDriver_pi::ShipDriver_pi(void* ppimgr)
     : opencpn_plugin_118(ppimgr)
@@ -234,11 +234,11 @@ const char *GetPlugInVersionBuild() { return PKG_BUILD_INFO; }
 
 wxBitmap* ShipDriver_pi::GetPlugInBitmap() { return &m_panelBitmap; }
 
-wxString ShipDriver_pi::GetCommonName() { return _("ShipDriver"); }
+wxString ShipDriver_pi::GetCommonName() { return PLUGIN_API_NAME; }
 
-wxString ShipDriver_pi::GetShortDescription() { return _("ShipDriver player"); }
+wxString ShipDriver_pi::GetShortDescription() { return PKG_SUMMARY; }
 
-wxString ShipDriver_pi::GetLongDescription() { return _("Almost a simulator"); }
+wxString ShipDriver_pi::GetLongDescription() { return PKG_DESCRIPTION; }
 
 int ShipDriver_pi::GetToolbarToolCount(void) { return 1; }
 
@@ -537,5 +537,5 @@ void ShipDriver_pi::SetNMEASentence(wxString& sentence)
 {
     if (NULL != m_pDialog) {
         m_pDialog->SetNMEAMessage(sentence);
-    }         
+    }
 }


### PR DESCRIPTION
The current implementations of  `GetCommonName()`, `GetShortDescription()` and `GetLongDescription()` are basically broken . If they were sane they would return the data in Plugin.cmake which is used in the catalog.

However, they don't. Instead they return  some more or less random data which is hard to maintain.

Until now this has not been that important, after all almost all visible content is taken from the catalog. Upcoming changes makes this more of a problem and we need to fix this. This is a tentative patch which perhaps could need some polish.

Note the new  FIX_PLUGIN_INFO.md. The work done in this patch needs to be applied manually in each plugin using the template.

Closes: #572