### PR TITLE
cmake/GetArch: Return correct x86 on windows (#573)

### DIFF
--- a/cmake/GetArch.cmake
+++ b/cmake/GetArch.cmake
@@ -48,9 +48,7 @@ function (GetArch)
       endif ()
     endif ()
   else (NOT WIN32)
-    # Should really be i386 since we are on win32. However, it's x86_64 for now,
-    # see #2027
-    set(ARCH "x86_64")
+    set(ARCH "x86")   # See #573
   endif ()
   set(ARCH ${ARCH} PARENT_SCOPE)
 endfunction (GetArch)


### PR DESCRIPTION
Follow up to #573. The value from GetArch is currently not used, but updated for consistensy.