### PR TITLE
Update wxWidgets build dependencies

### DIFF
--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -81,11 +81,11 @@ python -m pip install -q cryptography
 ::
 set SCRIPTDIR=%~dp0
 if "%~1"=="wx32" (
-  set "WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.2.2.1"
+  set "WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.2.4"
   set "wxWidgets_ROOT_DIR=!WXWIN!"
   set "wxWidgets_LIB_DIR=!WXWIN!\lib\vc14x_dll"
 ) else (
-  set "WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.2.2.1"
+  set "WXWIN=%SCRIPTDIR%..\cache\wxWidgets-3.2.4"
   set "wxWidgets_ROOT_DIR=!WXWIN!"
   set "wxWidgets_LIB_DIR=!WXWIN!\lib\vc_dll"
 )
@@ -98,15 +98,15 @@ echo set "wxWidgets_LIB_DIR=%wxWidgets_LIB_DIR%" >> %CONFIG_FILE%
 if not exist "%WXWIN%" (
   wget --version > nul 2>&1 || choco install -y wget
   if  "%~1"=="wx32" (
-      echo Downloading 3.2.2.1
-      if not exist  %SCRIPTDIR%..\cache\wxWidgets-3.2.2.1 (
-          mkdir %SCRIPTDIR%..\cache\wxWidgets-3.2.2.1
+      echo Downloading 3.2.4
+      if not exist  %SCRIPTDIR%..\cache\wxWidgets-3.2.4 (
+          mkdir %SCRIPTDIR%..\cache\wxWidgets-3.2.4
       )
       set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
-      wget -nv !GITHUB_DL!/v3.2.2.1/wxMSW-3.2.2_vc14x_Dev.7z
-      7z x -o%SCRIPTDIR%..\cache\wxWidgets-3.2.2.1 wxMSW-3.2.2_vc14x_Dev.7z
-      wget -nv !GITHUB_DL!/v3.2.2.1/wxWidgets-3.2.2.1-headers.7z
-      7z x -o%SCRIPTDIR%..\cache\wxWidgets-3.2.2.1 wxWidgets-3.2.2.1-headers.7z
+      wget -nv !GITHUB_DL!/v3.2.4/wxMSW-3.2.4_vc14x_Dev.7z
+      7z x -o%SCRIPTDIR%..\cache\wxWidgets-3.2.4 wxMSW-3.2.4_vc14x_Dev.7z
+      wget -nv !GITHUB_DL!/v3.2.4/wxWidgets-3.2.4-headers.7z
+      7z x -o%SCRIPTDIR%..\cache\wxWidgets-3.2.4 wxWidgets-3.2.4-headers.7z
   ) else (
       echo Downloading 3.1.2
       wget -O wxWidgets-3.1.2.7z -nv ^

--- a/ci/circleci-build-debian-armhf.sh
+++ b/ci/circleci-build-debian-armhf.sh
@@ -46,7 +46,7 @@ function install_wx32() {
   chmod a+w /usr/local/pkg
   repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.2+dfsg-1~bpo11+1"
+  vers="3.2.4+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
   wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_armhf.deb
   wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb

--- a/ci/circleci-build-debian-docker.sh
+++ b/ci/circleci-build-debian-docker.sh
@@ -46,7 +46,7 @@ function install_wx32() {
   chmod a+w /usr/local/pkg
   repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.2+dfsg-1~bpo11+1"
+  vers="3.2.4+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
   wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_arm64.deb
   wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb

--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -34,7 +34,7 @@ function install_wx32() {
   sudo chmod a+w /usr/local/pkg
   repo="https://dl.cloudsmith.io/public/alec-leamas/wxwidgets-32"
   head="deb/debian/pool/bullseye/main"
-  vers="3.2.2+dfsg-1~bpo11+1"
+  vers="3.2.4+dfsg-1~bpo11+1"
   pushd /usr/local/pkg
   wget -q $repo/$head/w/wx/wx-common_${vers}/wx-common_${vers}_amd64.deb
   wget -q $repo/$head/w/wx/wx3.2-i18n_${vers}/wx3.2-i18n_${vers}_all.deb

--- a/cmake/MacosWxwidgets.cmake
+++ b/cmake/MacosWxwidgets.cmake
@@ -12,7 +12,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 set(wx_repo https://github.com/wxWidgets/wxWidgets.git)
-set(wx_tag v3.2.2.1)
+set(wx_tag v3.2.4)
 
 option(IGNORE_SYSTEM_WX "Never use system wxWidgets installation" FALSE)
 


### PR DESCRIPTION
Update the bundled wxWidgets version used in various builds to 3.2.4.

Bookworm uses the system libraries which are on 3.2.2, no plans to change that. This means that the outdated bullseye builds have a more recent version than bullseye. Interesting... 

Closes: #564