### PR TITLE
CI images update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-bullseye-armhf:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - TARGET_TUPLE: debian-armhf;11;armhf
@@ -59,7 +59,7 @@ jobs:
 
   build-bullseye-wx32-armhf:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - TARGET_TUPLE: debian-wx32-armhf;11;armhf
@@ -75,7 +75,7 @@ jobs:
 
   build-bullseye-arm64:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: bullseye
@@ -89,7 +89,7 @@ jobs:
 
   build-bullseye-wx32-arm64:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: bullseye
@@ -105,7 +105,7 @@ jobs:
 
   build-bookworm:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:current
     resource_class: medium
     environment:
       - OCPN_TARGET: bookworm
@@ -119,7 +119,7 @@ jobs:
 
   build-bookworm-arm64:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: bookworm
@@ -133,7 +133,7 @@ jobs:
 
   build-bookworm-armhf:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - TARGET_TUPLE: debian-armhf;12;armhf
@@ -147,7 +147,7 @@ jobs:
 
   build-flatpak-arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: flatpak-arm64
@@ -161,7 +161,7 @@ jobs:
 
   build-flatpak-x86:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:current
     environment:
       - OCPN_TARGET: flatpak
       - CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: "12.5.1"
+      xcode: "15.2.0"
     environment:
       - OCPN_TARGET: macos
       - CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/build-deps/macos-deps
+++ b/build-deps/macos-deps
@@ -2,6 +2,5 @@
 cmake
 gettext
 libexif
-python
 wget
 openssl@3

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -20,6 +20,7 @@ set -x
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
 if [ -d /ci-source ]; then cd /ci-source; fi
 
+git config --global protocol.file.allow always
 git submodule update --init opencpn-libs
 
 # Set up build directory and a visible link in /

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -46,8 +46,8 @@ if [ -n "$CI" ]; then
         | sudo apt-key add -
 
     # Use updated flatpak (#457)
-    sudo add-apt-repository -y ppa:alexlarsson/flatpak
-    sudo apt update
+    #sudo add-apt-repository -y ppa:alexlarsson/flatpak
+    #sudo apt update
 
     # Install or update flatpak and flatpak-builder
     sudo apt install flatpak flatpak-builder

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -79,12 +79,6 @@ python3 -m pip install -q --user cloudsmith-cli
 # Required by git-push
 python3 -m pip install -q --user cryptography
 
-# python3 installs in odd place not on PATH, teach upload.sh to use it:
-pyvers=$(python3 --version | awk '{ print $2 }')
-pyvers=$(echo $pyvers | sed -E 's/[\.][0-9]+$//')    # drop last .z in x.y.z
-py_dir=$(ls -d  /Users/*/Library/Python/$pyvers/bin)
-echo "export PATH=\$PATH:$py_dir" >> ~/.uploadrc
-
 # Create the cached /usr/local archive
 if [ -n "$CI"  ]; then
   tar -C /usr -cf /tmp/local.cache.tar  local


### PR DESCRIPTION
Update images used for Linux, flatpak and macOS builds to the latest available as CCI is phasing out support for the currently used ones.