### PR TITLE
Flatpak: Add new 24.08 beta builds  (#598)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ jobs:
     environment:
       - OCPN_TARGET: flatpak-arm64
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: stable
     parameters:
       cache-key:
         type: string
@@ -159,18 +160,50 @@ jobs:
         default: "fp-arm20-v2"
     <<: *flatpak-steps
 
+  build-flatpak-arm64-2408:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.medium
+    environment:
+      - OCPN_TARGET: flatpak-arm64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: beta
+    parameters:
+      cache-key:
+        type: string
+        # Update the last part, here v2, to invalidate cache
+        default: "fp-arm20-v2"
+    <<: *flatpak-steps
+
+
   build-flatpak-x86:
     machine:
       image: ubuntu-2204:current
     environment:
       - OCPN_TARGET: flatpak
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: stable
     parameters:
       cache-key:
         type: string
         # Update the last part, here v2, to invalidate cache
         default: "fp-x86-20-v2"
     <<: *flatpak-steps
+
+  build-flatpak-x86-2408:
+    machine:
+      image: ubuntu-2204:current
+    environment:
+      - OCPN_TARGET: flatpak
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: beta
+    parameters:
+      cache-key:
+        type: string
+        # Update the last part, here v2, to invalidate cache
+        default: "fp-x86-20-v2"
+    <<: *flatpak-steps
+
 
   build-macos:
     macos:
@@ -237,6 +270,12 @@ workflows:
           <<: *std-filters
 
       - build-flatpak-x86:
+          <<: *std-filters
+
+      - build-flatpak-arm64-2408:
+          <<: *std-filters
+
+      - build-flatpak-x86-2408:
           <<: *std-filters
 
       - build-macos:

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -16,6 +16,15 @@ MANIFEST=$(cd flatpak; ls org.opencpn.OpenCPN.Plugin*yaml)
 echo "Using manifest file: $MANIFEST"
 set -x
 
+if [[ "$BRANCH" == beta ]]; then
+  export SDK=24.08
+  export FLATHUB_REPO=flathub-beta
+else
+  export SDK=22.08
+  export FLATHUB_REPO=flathub
+fi
+
+
 # Load local environment if it exists i. e., this is a local build
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
 if [ -d /ci-source ]; then cd /ci-source; fi
@@ -64,26 +73,25 @@ flatpak remote-add --user --if-not-exists flathub-beta \
     https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 flatpak remote-add --user --if-not-exists \
     flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-
-    # FIXME (leamas) revert to stable when 058 is published there
 flatpak install --user -y --noninteractive \
-    flathub org.freedesktop.Sdk//22.08
+    flathub org.freedesktop.Sdk//${SDK:-22.08}
 
 set -x
 cd $builddir
 
 # Patch the manifest to use correct branch and runtime unconditionally
 manifest=$(ls ../flatpak/org.opencpn.OpenCPN.Plugin*yaml)
-    # FIXME (leamas) restore beta -> stable when O58 is published
-sed -i  '/^runtime-version/s/:.*/: beta/'  $manifest
+sed -i  '/^runtime-version/s/:.*/:'" ${BRANCH:-stable}/"  $manifest
+sed -i  '/^sdk:/s|//.*|//'"${SDK:-22.08}|"  $manifest
 
 flatpak install --user -y --or-update --noninteractive \
-    flathub-beta  org.opencpn.OpenCPN
-flatpak remote-add --user --if-not-exists \
-    flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    ${FLATHUB_REPO:-flathub}  org.opencpn.OpenCPN
 
 # Configure and build the plugin tarball and metadata.
-cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} ..
+cmake \
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} \
+    -DOPN_TARGET_TUPLE="flatpak-$(uname -m);${SDK};$(uname -m)" \
+    ..
 # Do not build flatpak in parallel; make becomes unreliable
 make -j 1 VERBOSE=1 flatpak
 

--- a/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.shipdriver.yaml
@@ -1,8 +1,8 @@
 #
 # Branches and runtime-version:
 #   - master     Nigthly builds, 22.08 runtime
-#   - beta       Flathub beta branch with 22.08 runtime.
-#   - stable     Flathub main branch x86_64 with 20.08 runtime.
+#   - beta       Flathub beta branch with 24.08 runtime.
+#   - stable     Flathub main branch x86_64 with 22.08 runtime.
 #
 # This is a template used to create a complete manifest in the build
 # directory. Doing so, it handles three tokens:
@@ -19,7 +19,7 @@
 id: org.opencpn.OpenCPN.Plugin.@plugin_name
 
 runtime: org.opencpn.OpenCPN
-runtime-version: beta
+runtime-version: stable
 sdk: org.freedesktop.Sdk//22.08
 build-extension: true
 separate-locales: false

--- a/update-templates
+++ b/update-templates
@@ -189,7 +189,7 @@ sed -i 's|leamas/opencpn-libs|opencpn/opencpn-libs|g' \
 # Update flatpak runtime version as required:
 $SED_I \
     -e '/sdk: org.freedesktop.Sdk/s/20.08/22.08/' \
-    -e '/^runtime-version:/s/:.*/: beta/' \
+    -e '/^runtime-version:/s/:.*/: stable/' \
   flatpak/org.opencpn.OpenCPN.Plugin.*.yaml
 git add flatpak
 git diff-index --quiet --cached HEAD -- || {


### PR DESCRIPTION
The default runtime used when building Flatpak is as of flatpak/org.opencpn*.yaml. Hence, building with 24.08 must use something like -DOCPN_TARGET_TUPLE="flatpak-x86_64;24.08;x86_64"