### PR TITLE
Flatpak: Add new 24.08 beta builds - part 2 (#598)

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -90,7 +90,7 @@ flatpak install --user -y --or-update --noninteractive \
 # Configure and build the plugin tarball and metadata.
 cmake \
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} \
-    -DOPN_TARGET_TUPLE="flatpak-$(uname -m);${SDK};$(uname -m)" \
+    -DOCPN_TARGET_TUPLE="flatpak-$(uname -m);${SDK};$(uname -m)" \
     ..
 # Do not build flatpak in parallel; make becomes unreliable
 make -j 1 VERBOSE=1 flatpak


### PR DESCRIPTION
The default runtime used when building Flatpak is as of flatpak/org.opencpn*.yaml. Hence, building with 24.08 must use something like -DOCPN_TARGET_TUPLE="flatpak-x86_64;24.08;x86_64"

Smoke test using  the OpenCPN beta OK.