### PR TITLE
ci: Handle changed bullseye container permissions (#602)

### DIFF
--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -107,4 +107,4 @@ ldd app/*/lib/opencpn/*.so
 if [ -d /ci-source ]; then
     sudo chown --reference=/ci-source -R . ../cache || :
 fi
-sudo chmod --reference=.. .
+if [ -z "$CI" ]; then sudo chmod --reference=.. .; fi


### PR DESCRIPTION
The need to restore the build dir permissions is actually only on non-CI builds. Avoid problems which occurred after the Bullseye containers updated default permissions by leaving the CI build dir open on CI builds.

Closes: #602