### PR TITLE
Fix VTG formatting

### DIFF
--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -1301,7 +1301,7 @@ wxString Dlg::createVTGSentence(double mySpd, double myDir) {
   nSpd = wxString::Format("%f", mySpd);
   nDir = wxString::Format("%f", myDir);
 
-  nForCheckSum = nVTG + nDir + nC + nT + nC + nM + nSpd + nN + nC + nC + nA;
+  nForCheckSum = nVTG + nDir + nC + nT + nC + nM + nSpd + +nC + nN + nC + nC + nA;
 
   nFinal = ndlr + nForCheckSum + nast + makeCheckSum(nForCheckSum);
   // wxMessageBox(nFinal);


### PR DESCRIPTION
VTG sentence was missing a comma between "nSpeed" and "nN"

https://www.cruisersforum.com/forums/f134/shipdriver-plugin-malformed-nmea-295073.html