### PR TITLE
Fix HDT & Add missing values to VTG, VHW, DBT

### DIFF
--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -1317,22 +1317,13 @@ wxString Dlg::createHDTSentence(double myDir) {
   |   | |
   $--HDT, x.x, T*hh<CR><LF>
   */
-  wxString nSpd;
   wxString nDir;
-  wxString nTime;
-  wxString nDate;
-  wxString nValid;
   wxString nForCheckSum;
   wxString nFinal;
   wxString nC = ",";
-  wxString nA = "A";
-  wxString nT = "T,";
-  wxString nM = "M,";
-  wxString nN = "N,";
-  wxString nK = "K,";
+  wxString nT = "T";
 
   wxString nHDG = "IIHDT,";
-  nValid = "A,A";
   wxString ndlr = "$";
   wxString nast = "*";
 
@@ -1341,7 +1332,7 @@ wxString Dlg::createHDTSentence(double myDir) {
   nForCheckSum = nHDG + nDir + nC + nT;
 
   nFinal = ndlr + nForCheckSum + nast + makeCheckSum(nForCheckSum);
-  // wxMessageBox(nFinal);
+
   return nFinal;
 }
 

--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -988,35 +988,34 @@ wxString Dlg::createVHWSentence(double stw, double hdg) {
   2) T = True
   3) Degrees Magnetic
   4) M = Magnetic
-  5) Knots(speed of vessel relative to the water)
+  5) Knots (speed of vessel relative to the water)
   6) N = Knots
-  7) Kilometers (speed of vessel relative to the water)
-  8) K = Kilometres
+  7) Km/h (speed of vessel relative to the water)
+  8) K = Kilometers per hour
   9) Checksum
   */
-  wxString nVHW;
+
+  wxString nVHW = "IIVHW";
   wxString nDir;
-  wxString nTrue;
-  wxString nMag;
-  wxString nSpd;
-  wxString nValid;
+  wxString nTrue = "T";
+  wxString nMag = "M";
+  wxString nSpdN;
+  wxString nSpdK;
   wxString nForCheckSum;
   wxString nFinal;
-  wxString nUnits;
+  wxString nN = "N";
+  wxString nK = "K";
   wxString nC = ",";
-  wxString nA = "A";
-  nUnits = "N";
-  nVHW = "IIVHW";
-  nTrue = "T";
-  nMag = "M";
   wxString ndlr = "$";
   wxString nast = "*";
 
-  nSpd = wxString::Format("%f", stw);
+  nSpdN = wxString::Format("%f", stw);
+  nSpdK = wxString::Format("%f", stw * KNOT_2_KPH);
   nDir = wxString::Format("%f", hdg);
 
-  nForCheckSum = nVHW + nC + nDir + nC + nTrue + nC + nC + nMag + nC + nSpd +
-                 nC + nUnits + nC + nC + "K";
+  nForCheckSum = nVHW + nC + nDir + nC + nTrue + nC + nC + nMag + nC + nSpdN +
+                 nC + nN + nC + nSpdK + nC + nK;
+
   nFinal = ndlr + nForCheckSum + nast + makeCheckSum(nForCheckSum);
   return nFinal;
 }

--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -658,6 +658,7 @@ void Dlg::OnClose(wxCloseEvent& event) {
   if (m_timer->IsRunning()) m_timer->Stop();
   plugin->OnShipDriverDialogClose();
 }
+
 void Dlg::Notify() {
   wxString mySentence;
   plugin->SetNMEASentence(mySentence);
@@ -875,7 +876,7 @@ void Dlg::Notify() {
   VHW = createVHWSentence(initSpd, myDir);
   RMC = createRMCSentence(mdt, initLat, initLon, initSpd, myDir);
   HDT = createHDTSentence(myDir);
-  MDBT = createDBTSentence(1.0);
+  MDBT = createDBTSentence(10.0);
 
   PushNMEABuffer(GLL + "\r\n");
   PushNMEABuffer(VTG + "\r\n");
@@ -1623,41 +1624,38 @@ wxString Dlg::createDSCAlertRelayCancelSentence(double lat, double lon,
   return nFinal;
 }
 
-/*
-$--DBT,a.a,F,b.b,M,c.c,F*hh<CR><LF>
 
-    $--: Talker identifier*
-    DBT: Sentence formatter*
-    a.a,F: Water depth, feet*
-    b.b,M: Water depth, meters*
-    c.c,F: Water depth, fathoms*
-    *hh: Checksum*
+wxString Dlg::createDBTSentence(double myDepthMeter) {
+  /*
+  $--DBT,a.a,F,b.b,M,c.c,F*hh<CR><LF>
 
-*/
-wxString Dlg::createDBTSentence(double myDepth) {
-  wxString nDepth;
-  wxString nDir;
-  wxString nTime;
-  wxString nDate;
-  wxString nValid;
+   $--: Talker identifier*
+   DBT: Sentence formatter*
+   a.a,F: Water depth, feet*
+   b.b,M: Water depth, meters*
+   c.c,F: Water depth, fathoms*
+   *hh: Checksum*
+   */
+
+  wxString nDBT = "IIDBT";
+  wxString nDepthMeter;
+  wxString nDepthFeet;
+  wxString nDepthFathom;
   wxString nForCheckSum;
   wxString nFinal;
   wxString nC = ",";
-  wxString nA = "A";
-  wxString nT = "T,";
-  wxString nM = "M,";
-  wxString nN = "N,";
-  wxString nK = "K,";
-  wxString nF = "F";
-
-  wxString nDeep = "IIDBT,";
-  nValid = "A,A";
+  wxString nFeet = "f";
+  wxString nMeter = "M";
+  wxString nFathom = "F";
   wxString ndlr = "$";
   wxString nast = "*";
 
-  nDepth = wxString::Format("%f", myDepth);
+  nDepthMeter = wxString::Format("%f", myDepthMeter);
+  nDepthFeet = wxString::Format("%f", myDepthMeter * METER_2_FEET);
+  nDepthFathom = wxString::Format("%f", myDepthMeter * METER_2_FATHOM);
 
-  nForCheckSum = nDeep + nC + nC + nDepth + nC + nM + nC + nF;
+  nForCheckSum =
+      nDBT + nC + nDepthFeet + nC + nFeet + nC + nDepthMeter + nC + nMeter + nC + nDepthFathom + nC + nFathom;
 
   nFinal = ndlr + nForCheckSum + nast + makeCheckSum(nForCheckSum);
 
@@ -1735,6 +1733,7 @@ wxString Dlg::LatitudeToString(double mLat) {
 
   return returnLat;
 }
+
 double StringToLongitude(wxString mLon) {
   wxString mBitLon = "";
   wxString mDecLon;

--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -1279,7 +1279,8 @@ wxString Dlg::createGLLSentence(wxDateTime myDateTime, double myLat,
 wxString Dlg::createVTGSentence(double mySpd, double myDir) {
   //$GPVTG, 054.7, T, 034.4, M, 005.5, N, 010.2, K * 48
   //$IIVTG, 307., T, , M, 08.5, N, 15.8, K, A * 2F
-  wxString nSpd;
+  wxString nSpdN;
+  wxString nSpdK;
   wxString nDir;
   wxString nTime;
   wxString nDate;
@@ -1298,11 +1299,12 @@ wxString Dlg::createVTGSentence(double mySpd, double myDir) {
   wxString ndlr = "$";
   wxString nast = "*";
 
-  nSpd = wxString::Format("%f", mySpd);
+  nSpdN = wxString::Format("%f", mySpd);
+  nSpdK = wxString::Format("%f", mySpd*KNOT_2_KPH);
   nDir = wxString::Format("%f", myDir);
 
   nForCheckSum =
-      nVTG + nDir + nC + nT + nC + nM + nSpd + nC + nN + nC + nC + nA;
+      nVTG + nDir + nC + nT + nC + nM + nSpdN + nC + nN + nSpdK + nC + nK + nA;
 
   nFinal = ndlr + nForCheckSum + nast + makeCheckSum(nForCheckSum);
   // wxMessageBox(nFinal);

--- a/src/shipdriver_gui_impl.h
+++ b/src/shipdriver_gui_impl.h
@@ -59,6 +59,7 @@
 
 #define ID_SOMETHING 2001
 #define ID_SOMETHING_ELSE 2002
+#define KNOT_2_KPH 1.852
 
 #ifdef __WXOSX__
 #define SHIPDRIVER_DLG_STYLE \

--- a/src/shipdriver_gui_impl.h
+++ b/src/shipdriver_gui_impl.h
@@ -59,7 +59,10 @@
 
 #define ID_SOMETHING 2001
 #define ID_SOMETHING_ELSE 2002
+
 #define KNOT_2_KPH 1.852
+#define METER_2_FEET 3.280839895
+#define METER_2_FATHOM 0.5468066492
 
 #ifdef __WXOSX__
 #define SHIPDRIVER_DLG_STYLE \
@@ -135,6 +138,7 @@ public:
                              double mySpd, double myDir);
   wxString createVTGSentence(double mySpd, double myDir);
   wxString createHDTSentence(double myDir);
+  wxString createDBTSentence(double myDepthMeter);
 
   // DSC Sentences
   wxString createDSCAlertSentence(double lat, double lon, int mmsi,
@@ -336,8 +340,6 @@ private:
   bool m_bInvalidPolarsFile;
   bool m_bInvalidGribFile;
   bool m_bShipDriverHasStarted;
-
-  wxString createDBTSentence(double myDepth);
 
   Plugin_WaypointExList* myList;
 };


### PR DESCRIPTION
### HDT
Removed extraneous "," after "T" in HDT
Removed unused and useless wxStrings   

### VTG & VHW
Added Kph speed to complete the sentence
Added a macro to convert knot to kph
Removed unused and useless wxStrings 

### DBT
Added feet and fathoms depths to  complete the sentence
Added a macro to convert meter to feet and meter to fathom
Changed depth value to 10
Moved NMEA sentence example inside the createDBT( ) like for every other functions.
Removed unused and useless wxStrings 

### Merge
Merged commits of 28/06/2025 (v3.4.2 to v3.4.4)
