### PR TITLE
fix NMEA time interval calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ plugins
 *.bat
 *.bak
 buildwin/*.7z
+*.user
 

--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -851,9 +851,8 @@ void Dlg::Notify() {
 
   if (m_bUseFile) nmeafile->AddLine(myNMEAais);
 
-  int ss = 1;
-  wxTimeSpan mySeconds = wxTimeSpan::Seconds(ss);
-  wxDateTime mdt = dt.Add(mySeconds);
+  wxTimeSpan myTimeInterval = wxTimeSpan::Milliseconds(m_interval);
+  wxDateTime mdt = dt.Add(myTimeInterval);
 
   bool m_bGrib = false;
   double wspd, wdir;


### PR DESCRIPTION
- 1 second was added to mdt every 500ms (publish rate is 2Hz because m_interval=500) causing the RMC and GLL time to be two times faster than reality
- Added *.user to .gitignore to remove CMakeLists.txt.user file when programming with QtCreator