### PR TITLE
CMakeLists: Don't rebuild  flatpak twice - #519

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include(Plugin.cmake)
 project(${PKG_NAME} VERSION ${PKG_VERSION})
 include(PluginCompiler)
 
-add_library(${CMAKE_PROJECT_NAME} SHARED EXCLUDE_FROM_ALL ${SRC})
+add_library(${CMAKE_PROJECT_NAME} SHARED EXCLUDE_FROM_ALL cmake/dummy.cpp)
 include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
 
 add_subdirectory("opencpn-libs/${PKG_API_LIB}")
@@ -76,8 +76,9 @@ if ("${BUILD_TYPE}" STREQUAL "")
   return ()
 endif ()
 
- 
+
 if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
+  target_sources(${CMAKE_PROJECT_NAME} PUBLIC ${SRC})
   # Build package as required (flatpak already dealt with).
   #
   if (APPLE)
@@ -92,7 +93,7 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   include(PluginLocalization)
 
   include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
- 
+
   if (COMMAND add_plugin_libraries)
     add_plugin_libraries()
   endif ()

--- a/cmake/CmakeSetup.cmake
+++ b/cmake/CmakeSetup.cmake
@@ -6,6 +6,10 @@ if (POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif ()
 
+if (POLICY CMP0076)
+  cmake_policy(SET CMP0076 NEW)
+endif ()
+
 if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif ()

--- a/cmake/dummy.cpp
+++ b/cmake/dummy.cpp
@@ -1,0 +1,1 @@
+int DontEverCallMe() { return 43; }


### PR DESCRIPTION
At last found a simple fix for this. The build now only builds the source files once. There is still a duplicated install step in some situations, we can live with that.

Closes: #519