### PR TITLE
ci: debian: Use Release as default target - #514

### DIFF
--- a/ci/circleci-build-debian.sh
+++ b/ci/circleci-build-debian.sh
@@ -101,7 +101,7 @@ python3 -m pip install --user -q cloudsmith-cli cryptography cmake
 
 cd $builddir
 
-cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDbgInfo}" $TARGET_OPT ..
+cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}" $TARGET_OPT ..
 make VERBOSE=1 tarball
 ldd app/*/lib/opencpn/*.so
 if [ -d /ci-source ]; then


### PR DESCRIPTION
Libraries are actually stripped on all platforms besides Debian which has a buggy RelWithDbgInfo build type. Use Release also here.

If/when there is a need to build debug builds using the CI scripts CMAKE_BUILD_TYPE can be set in .circleci/config.yml. Setting this to Debug means that nothing is stripped.

Closes: #514