### PR TITLE
update-templates: syntax bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+3.4.3 Dec 28, 2025
+* update-templates: syntax bugfix
+
 3.4.2 Nov 13, 2025
 * .circleci/config: Formatting bugfix
 

--- a/update-templates
+++ b/update-templates
@@ -248,7 +248,7 @@ if [ -e update-ignored ]; then
     done
 fi
 
-if [ git grep -q libunarr-dev build-deps/control ]; then
+if git grep -q libunarr-dev build-deps/control; then
     $SED_I -e '/libunarr/s/^.*$/libarchive-dev (>= 3.7.4) | libunarr-dev,/' \
       build-deps/control
 fi


### PR DESCRIPTION
Fix a bug  introduced  by me in 171859ae

IMHO this warrants a new sd3.4.3 tag. I have updated the changelog, not pushing any tag right now.

EDIT: The run completes, but the bug causes error message: `./update-templates: line 251: [: too many arguments`