### PR TITLE
Use local GRIB timeline time

### DIFF
--- a/src/shipdriver_gui_impl.cpp
+++ b/src/shipdriver_gui_impl.cpp
@@ -1937,8 +1937,8 @@ double Dlg::GetPolarSpeed(double lat, double lon, double cse) {
   double spd;
   double dir;
 
-  wxDateTime dt;
-  dt = wxDateTime::UNow();
+  wxDateTime dt = m_GribTimelineTime.IsValid() ? m_GribTimelineTime
+                                               : wxDateTime::Now();
 
   bool m_bGrib = GetGribSpdDir(dt, lati, loni, spd, dir);
   if (!m_bGrib) {

--- a/src/shipdriver_pi.cpp
+++ b/src/shipdriver_pi.cpp
@@ -482,7 +482,7 @@ void ShipDriverPi::SetPluginMessage(wxString& message_id,
              value["Minute"].asInt(), value["Second"].asInt());
 
     if (m_dialog) {
-      m_dialog->m_GribTimelineTime = time.ToUTC();
+      m_dialog->m_GribTimelineTime = time;
       // m_pDialog->m_textCtrl1->SetValue(dt);
     }
   }


### PR DESCRIPTION
## Summary
- store the GRIB timeline exactly as received instead of converting it to UTC
- request GRIB timeline records using the active local GRIB timeline when available
- fall back to `wxDateTime::Now()` instead of `wxDateTime::UNow()`

Fixes #649
