### PR TITLE
ci: flatpak: Remove bundled libusb for runtime 25.08+ - #641

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -92,6 +92,12 @@ cd $builddir
 manifest=$(ls ../flatpak/org.opencpn.OpenCPN.Plugin*yaml)
 sed -i  '/^runtime-version/s/:.*/:'" ${FLATHUB_BRANCH:-stable}/"  $manifest
 sed -i  '/^sdk:/s|//.*|//'"${SDK:-24.08}|"  $manifest
+ 
+if (( "$BRANCH" >= 2508 )); then
+    # From 25.08 the runtime contains libusb. If manifest has added this,
+    # remove it.
+    sed -i '/libusb/,/name:/d' $manifest
+fi
 
 flatpak install --user -y --or-update --noninteractive \
     ${FLATHUB_REPO:-flathub}  org.opencpn.OpenCPN


### PR DESCRIPTION
From 25.08 the runtime contains libusb. This means linker collisions for modules  bundling libusb. Thus remove libusb from such manifests.

Closes: #641