### PR TITLE
Add IDE setup support - #634

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 build-*
 !build-conf.rc
 !build-deps
+ide_setup.cmake
 po/*.pot
 .DS_Store
 *humbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ if (COMMAND late_init)
   late_init()
 endif ()
 
+# Optional IDE setup, typically target_include_directories() etc.
+if (EXISTS ide_setup.cmake)
+  include(ide_setup.cmake)
+endif ()
+
 # Configure the flatpak manifest
 file(
   GLOB manifest ${PROJECT_SOURCE_DIR}/flatpak/org.opencpn.OpenCPN.Plugin.*.yaml
@@ -76,7 +81,6 @@ if ("${BUILD_TYPE}" STREQUAL "")
   return ()
 endif ()
 
- 
 if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   # Build package as required (flatpak already dealt with).
   #
@@ -92,11 +96,10 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   include(PluginLocalization)
 
   include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
- 
+
   if (COMMAND add_plugin_libraries)
     add_plugin_libraries()
   endif ()
-
 endif ()
 
 configure_file(


### PR DESCRIPTION
IDEs like CLion are confused by out two step cmake process since the initial cmake command does not set up include paths, etc.

Add support for an optional file ide_setup.cmake which if existing is included. This allows for setting up paths so CLion is happy.

The file is not part of the repo and is not used in CI builds.

Closes: #634   (more documentation needed, though).